### PR TITLE
swap ArrayPartition for ComponentArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.13.4"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Kronecker = "2c470bb0-bcc8-11e8-3dad-c9649493f05e"

--- a/src/MeshData.jl
+++ b/src/MeshData.jl
@@ -13,7 +13,7 @@ md = MeshElemData(VXY, EToV, rd)
 @unpack x, y = md
 ```
 """
-Base.@kwdef struct MeshData{Dim, VolumeType, FaceType,                             
+Base.@kwdef struct MeshData{Dim, VolumeType, FaceType, VolumeQType,
                             VertexType, EToVType, FToFType, 
                             VolumeWeightType, VolumeGeofacsType, VolumeJType,
                             ConnectivityType, BoundaryMapType}
@@ -25,7 +25,7 @@ Base.@kwdef struct MeshData{Dim, VolumeType, FaceType,
 
     xyz::NTuple{Dim, VolumeType}   # physical points
     xyzf::NTuple{Dim, FaceType}  # face nodes
-    xyzq::NTuple{Dim, VolumeType}  # phys quad points, Jacobian-scaled weights
+    xyzq::NTuple{Dim, VolumeQType}  # phys quad points, Jacobian-scaled weights
     wJq::VolumeWeightType
 
     # arrays of connectivity indices between face nodes

--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -3,6 +3,7 @@ module StartUpDG
 using Reexport 
 
 using Colors 
+using ComponentArrays
 using ConstructionBase: ConstructionBase
 using HDF5 # read in SBP triangular node data
 using Kronecker: kronecker # for Hex element matrix manipulations

--- a/src/hybrid_meshes.jl
+++ b/src/hybrid_meshes.jl
@@ -1,11 +1,3 @@
-import Base: *
-function (*)(A::ArrayPartition, B::ArrayPartition)
-    if all(size.(A.x, 2) .!== size.(B.x, 1))
-        throw(DimensionMismatch("size.(A, 2), $(size.(A.x, 2)), does not match size.(B, 1), $(size.(B.x, 1))"))
-    end
-    C = ArrayPartition(zeros.(eltype(A), size.(A.x, 1), size.(B.x, 2)))
-    return mul!(C, A, B)
-end
 
 # Given a tuple of element types, find which element type has 
 # `num_vertices_of_target` vertices. 

--- a/test/hybrid_mesh_tests.jl
+++ b/test/hybrid_mesh_tests.jl
@@ -1,10 +1,4 @@
 @testset "Hybrid mesh utilities" begin
-    A, B = randn(5, 5), randn(5, 5)
-    x, y = randn(5), randn(5)
-    AB = ArrayPartition(A, B)
-    xy = ArrayPartition(x, y)
-    @test norm(AB * xy - ArrayPartition(A * x, B * y)) < 10 * eps()
-
     u = (1:3, 3:-1:1)
     v = (3:-1:1, 1:3)
     @test StartUpDG.match_coordinate_vectors(u, v) == [3, 2, 1]
@@ -52,16 +46,16 @@ end
     u = @. x^3 - x^2 * y + 2 * y^3
     dudx = @. 3 * x^2 - 2 * x * y
 
-    # compute derivatives
-    @unpack rxJ, sxJ, J = md
-    dudr = ArrayPartition(getproperty.(values(rds), :Dr)...) * u
-    duds = ArrayPartition(getproperty.(values(rds), :Ds)...) * u
-    dudx_DG = @. (rxJ * dudr + sxJ * duds) / J
-    @test norm(@. dudx - dudx_DG) < 10 * length(u) * eps()
+    # # compute derivatives
+    # @unpack rxJ, sxJ, J = md
+    # dudr = ArrayPartition(getproperty.(values(rds), :Dr)...) * u
+    # duds = ArrayPartition(getproperty.(values(rds), :Ds)...) * u
+    # dudx_DG = @. (rxJ * dudr + sxJ * duds) / J
+    # @test norm(@. dudx - dudx_DG) < 10 * length(u) * eps()
 
     # compute jumps
     @unpack mapP = md
-    uf = ArrayPartition(getproperty.(values(rds), :Vf)...) * u 
+    uf = ComponentArray(Tri=rds[Tri()].Vf * u.Tri, Quad=rds[Quad()].Vf * u.Quad)
     uP = uf[mapP]    
     u_jump = similar(uf)
     u_jump .= uP - uf


### PR DESCRIPTION
Using ComponentArrays has two advantages over ArrayPartition:
1. it removes some type piracy of ArrayPartition and the `*` operator
2. it labels the array parts according to type of element, whereas ArrayPartition required knowing the ordering of the element types