### PR TITLE
remove unused type variable

### DIFF
--- a/src/ref_elem_utils.jl
+++ b/src/ref_elem_utils.jl
@@ -99,8 +99,8 @@ inverse_trace_constant(rd::RefElemData{3, Hex, SBP{TensorProductLobatto}}) = 3 *
 # precomputed
 _inverse_trace_constants(rd::RefElemData{2, Tri, Polynomial}) = (6.0, 10.898979485566365, 16.292060161853993, 23.999999999999808, 31.884512140579055, 42.42373503225737, 52.88579066878113, 66.25284319164409, 79.3535377715693, 95.53911875636945)
 _inverse_trace_constants(rd::RefElemData{3, Tet, Polynomial}) = (10., 16.892024376045097, 23.58210016200093, 33.828424659883034, 43.40423356477473, 56.98869932201791, 69.68035962892684)
-inverse_trace_constant(rd::RefElemData{2, Tri, Polynomial}) where {Dim} = _inverse_trace_constants(rd)[rd.N]
-inverse_trace_constant(rd::RefElemData{3, Tet, Polynomial}) where {Dim} = _inverse_trace_constants(rd)[rd.N]
+inverse_trace_constant(rd::RefElemData{2, Tri, Polynomial}) = _inverse_trace_constants(rd)[rd.N]
+inverse_trace_constant(rd::RefElemData{3, Tet, Polynomial}) = _inverse_trace_constants(rd)[rd.N]
 
 # generic fallback
 function inverse_trace_constant(rd::RefElemData)


### PR DESCRIPTION
Unused type variables can also lead to potential performance problems.