### PR TITLE
Add `CurvedMesh` type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ StartUpDG.jl follows the interpretation of [semantic versioning (semver)](https:
 #### Added 
 
 * the `NamedArrayPartition` array type, which is similar to `ComponentArrays` but with the storage structure of `ArrayPartition`. This is used for the storage of `MeshData` fields in hybrid and cut-cell meshes, and can be used for the storage of solutions compatible with the OrdinaryDiffEq.jl framework. 
+* Added a `CurvedMesh` type for `MeshData` constructed from modified nodal coordinates, e.g., using the constructor `MeshData(rd, md, xyz...)`. `CurvedMesh` stores the original mesh type as a field. 
 
 #### Changed
 

--- a/src/MeshData.jl
+++ b/src/MeshData.jl
@@ -349,14 +349,28 @@ function recompute_geometry(rd::RefElemData{Dim}, xyz) where {Dim}
     return xyzf, xyzq, rstxyzJ, J, wJq, nxyzJ, Jf
 end
 
+"""
+    struct CurvedMesh
+
+Mesh type indicating that the mesh has been curved. Stores the original mesh type as a field.
+
+# Fields
+original_mesh_type :: T\\
+"""
+struct CurvedMesh{T}
+    original_mesh_type::T
+end 
+
 function MeshData(rd::RefElemData, md::MeshData{Dim}, xyz...) where {Dim}
 
     xyzf, xyzq, rstxyzJ, J, wJq, nxyzJ, Jf = recompute_geometry(rd, xyz)
 
     nxyz = map(n -> n ./ Jf, nxyzJ)
 
+    mesh_type = CurvedMesh(md.mesh_type)
+
     # TODO: should we warp VXYZ as well? Or create a new mesh type?
-    return setproperties(md, (; xyz, xyzq, xyzf, rstxyzJ, J, wJq, nxyz, nxyzJ, Jf))
+    return setproperties(md, (; mesh_type, xyz, xyzq, xyzf, rstxyzJ, J, wJq, nxyz, nxyzJ, Jf))
 end
 
 

--- a/test/MeshData_tests.jl
+++ b/test/MeshData_tests.jl
@@ -191,6 +191,7 @@
             @test sum(@. md2.wJq * md2.xq^2) ≈ 4/3
             @test md2.nx ≈ md2.nxJ ./ md2.Jf
             @test md2.ny ≈ md2.nyJ ./ md2.Jf
+            @test typeof(md2) <: MeshData{2, <:StartUpDG.CurvedMesh}
         end
     end
 end


### PR DESCRIPTION
Add a `CurvedMesh` type to indicate when a `MeshData` has been created by a curved warping of nodal coordinates.