### PR TITLE
Add `Polynomial{Gauss}` type

### DIFF
--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -23,11 +23,13 @@ using Triangulate: Triangulate, TriangulateIO, triangulate
 
 # reference element utility functions
 include("RefElemData.jl")
+include("ref_elem_utils.jl")
+
 include("RefElemData_polynomial.jl")
+export RefElemData, Polynomial, GaussCollocation
+
 include("RefElemData_TensorProductWedge.jl")
 export TensorProductWedge
-include("ref_elem_utils.jl")
-export RefElemData, Polynomial
 
 include("RefElemData_SBP.jl")
 export SBP, DefaultSBPType, TensorProductLobatto, Hicken, Kubatko # types for SBP node dispatch

--- a/test/reference_elem_tests.jl
+++ b/test/reference_elem_tests.jl
@@ -185,8 +185,7 @@ inverse_trace_constant_compare(rd::RefElemData{3, <:Wedge, <:TensorProductWedge}
     (16.0, 20.898979485566365, 26.292060161853993, 33.99999999999981), 
     (21.0, 25.898979485566365, 31.292060161853993, 38.99999999999981))
 
-
-@testset "Tensor reference elements" begin
+@testset "Tensor product wedges" begin
     tol = 5e2*eps()
     @testset "Degree $tri_grad triangle" for tri_grad = [1, 2, 3, 4]
         @testset "Degree $line_grad line" for line_grad = [1, 2, 3, 4]
@@ -256,5 +255,20 @@ inverse_trace_constant_compare(rd::RefElemData{3, <:Wedge, <:TensorProductWedge}
 
         @test inverse_trace_constant(rd) ≈ inverse_trace_constant_compare(rd)[line_grad][tri_grad]
         end
+    end
+end
+
+ndims(::Line) = 1
+ndims(::Quad) = 2
+ndims(::Hex) = 3
+
+@testset "Tensor product Gauss collocation" begin
+    N = 3
+    @testset "element_type = $element_type" for element_type in [Line(), Quad(), Hex()]
+        rd = RefElemData(element_type, Polynomial{Gauss}(), N)
+
+        # test that quadrature is equivalent to interpolation
+        @test size(rd.Vq, 1) == size(rd.Vq, 2)        
+        @test length(rd.wq) == (N+1)^ndims(element_type)
     end
 end


### PR DESCRIPTION
This is motivated by the `GaussSBP` approximation type in Trixi.jl. It is treated as a separate approximation type from `Polynomial`, which makes some dispatch and code reuse difficult. 

Here, we add a type parameter to `Polynomial` approximation types to indicate structure within polynomial-based approximations. This should eventually replace `GaussSBP` approximation types in Trixi.jl. 