### PR TITLE
fix `approximation_type::Polynomial{Gauss}` constructor

### DIFF
--- a/src/RefElemData_SBP.jl
+++ b/src/RefElemData_SBP.jl
@@ -312,7 +312,7 @@ function sparse_low_order_SBP_operators(rd::RefElemData{NDIMS}) where {NDIMS}
     return sparse.(Qrst), sparse(E)
 end
 
-function sparse_low_order_SBP_1D_operators(rd::RefElemData{1}) 
+function sparse_low_order_SBP_1D_operators(rd::RefElemData) 
     E = zeros(2, rd.N+1)
     E[1, 1] = 1
     E[2, end] = 1

--- a/src/RefElemData_polynomial.jl
+++ b/src/RefElemData_polynomial.jl
@@ -356,9 +356,8 @@ function RefElemData(element_type::Union{Line, Quad, Hex},
                      approximation_type::Polynomial{<:Gauss}, N; kwargs...) 
     # explicitly specify Gauss quadrature rule with (N+1)^d points 
     quad_rule_vol = tensor_product_quadrature(element_type, StartUpDG.gauss_quad(0, 0, N)...)
-    rd = RefElemData(element_type, Polynomial(), N; quad_rule_vol)
-    @set rd.approximation_type = approximation_type
-    return rd
+    rd = RefElemData(element_type, Polynomial(), N; quad_rule_vol)    
+    return @set rd.approximation_type = approximation_type
 end
   
 RefElemData(element_type::Union{Line, Quad, Hex}, ::Gauss, N; kwargs...) = 

--- a/src/nonconforming.jl
+++ b/src/nonconforming.jl
@@ -93,7 +93,7 @@ end
 # one non-conforming quad face is split into 2 mortar faces
 num_mortars_per_face(rd::RefElemData{2, Quad}) = 2
 
-num_elements(md::MeshData{Dim, <:NonConformingMesh}) where {Dim} = size(getproperty(md.mesh_type, :EToV), 1)
+num_elements(md::MeshData{Dim, <:NonConformingMesh}) where {Dim} = size(getfield(getfield(md, :mesh_type), :EToV), 1)
 
 function MeshData(mesh::NonConformingQuadMeshExample, rd::RefElemData{2, Quad})
 

--- a/test/reference_elem_tests.jl
+++ b/test/reference_elem_tests.jl
@@ -292,6 +292,15 @@ end
         @test Qs + Qs' ≈ E' * Diagonal(rd.wf .* rd.nsJ) * E
     end
 
+    @testset "Quad (SBP)" begin
+        rd = RefElemData(Quad(), SBP(), N)
+        (Qr, Qs), E = sparse_low_order_SBP_operators(rd)
+        @test norm(sum(Qr, dims=2)) < tol
+        @test norm(sum(Qs, dims=2)) < tol
+        @test Qr + Qr' ≈ E' * Diagonal(rd.wf .* rd.nrJ) * E
+        @test Qs + Qs' ≈ E' * Diagonal(rd.wf .* rd.nsJ) * E
+    end
+
     @testset "Quad (Polynomial{Gauss})" begin
         rd = RefElemData(Quad(), Gauss(), N)
         (Qr, Qs), E = sparse_low_order_SBP_operators(rd)

--- a/test/reference_elem_tests.jl
+++ b/test/reference_elem_tests.jl
@@ -187,8 +187,8 @@ inverse_trace_constant_compare(rd::RefElemData{3, <:Wedge, <:TensorProductWedge}
 
 @testset "Tensor product wedges" begin
     tol = 5e2*eps()
-    @testset "Degree $tri_grad triangle" for tri_grad = [1, 2, 3, 4]
-        @testset "Degree $line_grad line" for line_grad = [1, 2, 3, 4]
+    @testset "Degree $tri_grad triangle" for tri_grad = [2, 3]
+        @testset "Degree $line_grad line" for line_grad = [1, 2]
         line = RefElemData(Line(), line_grad)
         tri  = RefElemData(Tri(), tri_grad)
         tensor = TensorProductWedge(tri, line)


### PR DESCRIPTION
Previously it was returning a more general "default" approximation type, now it returns `Polynomial{Gauss}`