### PR TITLE
Unify Gmsh accessors

### DIFF
--- a/src/MeshData.jl
+++ b/src/MeshData.jl
@@ -258,7 +258,7 @@ function MeshData(VX::AbstractVector, EToV, rd::RefElemData{1})
     xq = Vq * x
     wJq = diagm(wq) * (Vq * J)
 
-    is_periodic = (false,)
+    is_periodic = (false, )
 
     return MeshData(VertexMappedMesh(rd.element_type, tuple(VX), EToV), FToF,
                     tuple(x), tuple(xf), tuple(xq), wJq,

--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -72,7 +72,9 @@ export num_mortars_per_face, NonConformingQuadMeshExample
 include("mesh/simple_meshes.jl")
 export uniform_mesh
 include("mesh/gmsh_utilities.jl")
-export readGmsh2D, readGmsh2D_v4, MeshImportOptions
+export read_gmsh_2D
+export readGmsh2D, readGmsh2D_v4
+export MeshImportOptions 
 include("mesh/hohqmesh_utilities.jl")
 export read_HOHQMesh
 

--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -72,7 +72,7 @@ export num_mortars_per_face, NonConformingQuadMeshExample
 include("mesh/simple_meshes.jl")
 export uniform_mesh
 include("mesh/gmsh_utilities.jl")
-export read_gmsh_2D
+export read_Gmsh_2D
 export readGmsh2D, readGmsh2D_v4
 export MeshImportOptions 
 include("mesh/hohqmesh_utilities.jl")

--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -72,8 +72,8 @@ export num_mortars_per_face, NonConformingQuadMeshExample
 include("mesh/simple_meshes.jl")
 export uniform_mesh
 include("mesh/gmsh_utilities.jl")
-export read_Gmsh_2D
-export readGmsh2D, readGmsh2D_v4
+export read_Gmsh_2D # unifies v2.2.8 and v4.1 mesh reading
+export readGmsh2D, readGmsh2D_v4 # TODO: deprecate these
 export MeshImportOptions 
 include("mesh/hohqmesh_utilities.jl")
 export read_HOHQMesh

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -71,14 +71,14 @@ function remap_element_grouping(eg::Vector{Int})
 end
 
 """
- function read_Gmsh_2D_v4(filename)
+    function read_Gmsh_2D_v4(filename, options)
 
 reads triangular GMSH 2D .msh files.
 
 # Output
 This depends on if grouping is opted for or not
-- returns: (VX,VY), EToV
-- return:(VX,VY),EToV,grouping
+- returns: (VX, VY), EToV
+- returns: (VX, VY), EToV, grouping
 
 # Supported formats and features:
 - version 4.1
@@ -86,7 +86,7 @@ This depends on if grouping is opted for or not
     'remap group ids
 
 ## grouping application
-When modeling the wave equation you might want wave speeds to vary accross your domain. By assigning Physical groups
+When modeling the wave equation you might want wave speeds to vary across your domain. By assigning physical groups
 in Gmsh we can maintain such groupings upon importing the .msh file. Each imported element will be a member of a phyical group.
 
 ```julia
@@ -94,12 +94,12 @@ VXY, EToV = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh")
 VXY, EToV = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh",false)
 VXY, EToV, grouping = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh", true)
 
-option = MeshOption(true)
+option = MeshImportOption(true)
 VXY, EToV, grouping = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh", option)
 ```
 https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format
 
-Notes:The version 4 format has a more detailed block data format
+Notes: the version 4 format has a more detailed block data format
 this leads to more complicated parser.
 """
 function read_Gmsh_2D_v4(filename::String, options::MeshImportOptions)
@@ -116,7 +116,6 @@ function read_Gmsh_2D_v4(filename::String, options::MeshImportOptions)
     version, _, dataSize = split(lines[format_line])
     gmsh_version = parse(Float64, version)
     group_requested_but_none_in_file = false
-
 
     if gmsh_version == 4.1
         @info "reading Gmsh file with legacy ($gmsh_version) format"
@@ -229,8 +228,8 @@ function read_Gmsh_2D_v4(filename::String, options::MeshImportOptions)
 end
 
 """
-For brevity while grouping is the only supported feature this allows
-for simpler code
+For brevity when grouping is the only supported feature.
+
     example: VXY, EToV, grouping = read_Gmsh_2D_v4("file.msh",true)
     example: VXY, EToV = read_Gmsh_2D_v4("file.msh",false)
 """
@@ -240,8 +239,9 @@ function read_Gmsh_2D_v4(filename::String, groupOpt::Bool=false, remap_group_nam
 end
 
 """
-function read_Gmsh_2D(filename)
-reads triangular GMSH 2D file format 2.2 0 8. returns (VX, VY), EToV
+    read_Gmsh_2D(filename)
+
+Reads triangular GMSH 2D file format 2.2 0 8. Returns (VX, VY), EToV.
 # Examples
 ```julia
 VXY, EToV = read_Gmsh_2D("eulerSquareCylinder2D.msh")

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -117,11 +117,7 @@ function read_Gmsh_2D_v4(filename::String, options::MeshImportOptions)
     gmsh_version = parse(Float64, version)
     group_requested_but_none_in_file = false
 
-    if gmsh_version == 4.1
-        @info "reading Gmsh file with legacy ($gmsh_version) format"
-    else
-        @warn "Gmsh file version is: $gmsh_version; consider using a different parsing fuction for this file format"
-    end
+    @assert gmsh_version == 4.1
 
     # grouping may be requested yet not be present in the file
     if isnothing(findline("\$PhysicalNames", lines)) && grouping == true
@@ -294,13 +290,7 @@ function read_Gmsh_2D_v2(filename::String)
     format_line = findline("\$MeshFormat", lines) + 1
     version, _, dataSize = split(lines[format_line])
     gmsh_version = parse(Float64, version)
-    if gmsh_version == 2.2
-        @info "reading Gmsh file with legacy ($gmsh_version) format"
-    elseif gmsh_version == 4.1
-        @assert "This parsing function is not compatable with Gmsh version $gmsh_version"
-    else
-        @warn "Gmsh file version is: $gmsh_version; consider using a different parsing fuction for this file format"
-    end
+    @assert gmsh_version == 2.2
 
     node_start = findline("\$Nodes", lines) + 1
     Nv = parse(Int64, lines[node_start])

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -120,7 +120,7 @@ function read_Gmsh_2D_v4(filename::String, options::MeshImportOptions)
     if gmsh_version == 4.1
         @info "reading Gmsh file with legacy ($gmsh_version) format"
     else
-        @warn "Gmsh file version is: $gmsh_version consider using a different parsing fuction for this file format"
+        @warn "Gmsh file version is: $gmsh_version; consider using a different parsing fuction for this file format"
     end
 
     # grouping may be requested yet not be present in the file
@@ -261,7 +261,7 @@ function read_Gmsh_2D(filename::String)
     elseif gmsh_version == 4.1
         @assert "This parsing function is not compatable with Gmsh version $gmsh_version"
     else
-        @warn "Gmsh file version is: $gmsh_version consider using a different parsing fuction for this file format"
+        @warn "Gmsh file version is: $gmsh_version; consider using a different parsing fuction for this file format"
     end
 
     node_start = findline("\$Nodes", lines) + 1

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -228,6 +228,44 @@ function read_Gmsh_2D_v4(filename::String, options::MeshImportOptions)
 end
 
 """
+    read_Gmsh_2D(filename, args...)
+
+Reads a 2D triangular Gmsh file. Mesh formats 2.2 and 4.1 supported. 
+Returns (VX, VY), EToV. 
+
+# Examples
+```julia
+VXY, EToV = read_Gmsh_2D("eulerSquareCylinder2D.msh") # v2.2 file format
+VXY, EToV = read_Gmsh_2D("test/testset_Gmsh_meshes/periodicity_mesh_v4.msh") # v4.1 file format
+
+# if MeshImportOptions.grouping=true, then a third variable `grouping` is returned
+VXY, EToV, grouping = read_Gmsh_2D("test/testset_Gmsh_meshes/periodicity_mesh_v4.msh", MeshImportOptions(true, false))
+VXY, EToV, grouping = read_Gmsh_2D("test/testset_Gmsh_meshes/periodicity_mesh_v4.msh", true) # same as above
+```
+
+# See also
+https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format\\
+https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format-version-2-_0028Legacy_0029
+"""
+function read_Gmsh_2D(filename::String, args...)
+    f = open(filename)
+    lines = readlines(f)
+
+    format_line = findline("\$MeshFormat", lines) + 1
+    version, _ = split(lines[format_line])
+    gmsh_version = parse(Float64, version)
+    if gmsh_version == 2.2
+        @info "reading Gmsh file with legacy ($gmsh_version) format"
+        return read_Gmsh_2D_v2(filename)
+    elseif gmsh_version == 4.1
+        @info "reading Gmsh file with legacy ($gmsh_version) format"
+        return read_Gmsh_2D_v4(filename, args...)
+    else
+        @warn "Gmsh file version is: $gmsh_version; consider using a different parsing fuction for this file format"
+    end
+end
+
+"""
 For brevity when grouping is the only supported feature.
 
     example: VXY, EToV, grouping = read_Gmsh_2D_v4("file.msh",true)

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -239,17 +239,17 @@ function read_Gmsh_2D_v4(filename::String, groupOpt::Bool=false, remap_group_nam
 end
 
 """
-    read_Gmsh_2D(filename)
+    read_Gmsh_2D_v2(filename)
 
 Reads triangular GMSH 2D file format 2.2 0 8. Returns (VX, VY), EToV.
 # Examples
 ```julia
-VXY, EToV = read_Gmsh_2D("eulerSquareCylinder2D.msh")
+VXY, EToV = read_Gmsh_2D_v2("eulerSquareCylinder2D.msh")
 ```
 
 https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format-version-2-_0028Legacy_0029
 """
-function read_Gmsh_2D(filename::String)
+function read_Gmsh_2D_v2(filename::String)
     f = open(filename)
     lines = readlines(f)
 
@@ -324,5 +324,5 @@ function correct_negative_Jacobians!((VX, VY), EToV)
 end
 
 # TODO: deprecate these in major release 0.18 or 1.0 (whichever's first)
-@deprecate readGmsh2D(filename) read_Gmsh_2D(filename)
+@deprecate readGmsh2D(filename) read_Gmsh_2D_v2(filename)
 @deprecate readGmsh2D_v4(filename, args...) read_Gmsh_2D_v4(filename, args...)

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -16,7 +16,7 @@ end
 """
     MeshImportOptions
 This struct allows the user to opt for supported features when importing
-a gmsh 4.1 .msh file.
+a Gmsh 4.1 .msh file.
 ## Support
 - grouping::Bool | On import would you like to include physical group assignements of 2D elements?
 - remap\\_group\\_name::Bool | On import would you like to maintain or remap physical group ID? Remap results in groupIds in the range 1:number\\_group\\_ids.
@@ -51,7 +51,7 @@ end
 
 """
 remap_element_grouping!(eg::Vector{Int})
-GMSH uses integers for naming conventions. This function remaps the gmsh ids to
+GMSH uses integers for naming conventions. This function remaps the Gmsh ids to
 a list of ids 1:numGroups. This just cleans up a little after Gmsh
 ## Example output
 remap_element_grouping([16,16,17,17]) -> [1,1,2,2]
@@ -71,7 +71,7 @@ function remap_element_grouping(eg::Vector{Int})
 end
 
 """
- function readGmsh2D_v4(filename)
+ function read_Gmsh_2D_v4(filename)
 
 reads triangular GMSH 2D .msh files.
 
@@ -87,22 +87,22 @@ This depends on if grouping is opted for or not
 
 ## grouping application
 When modeling the wave equation you might want wave speeds to vary accross your domain. By assigning Physical groups
-in gmsh we can maintain such groupings upon importing the .msh file. Each imported element will be a member of a phyical group.
+in Gmsh we can maintain such groupings upon importing the .msh file. Each imported element will be a member of a phyical group.
 
 ```julia
-VXY, EToV = readGmsh2D_v4("eulerSquareCylinder2D.msh")
-VXY, EToV = readGmsh2D_v4("eulerSquareCylinder2D.msh",false)
-VXY, EToV, grouping = readGmsh2D_v4("eulerSquareCylinder2D.msh", true)
+VXY, EToV = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh")
+VXY, EToV = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh",false)
+VXY, EToV, grouping = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh", true)
 
 option = MeshOption(true)
-VXY, EToV, grouping = readGmsh2D_v4("eulerSquareCylinder2D.msh", option)
+VXY, EToV, grouping = read_Gmsh_2D_v4("eulerSquareCylinder2D.msh", option)
 ```
 https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format
 
 Notes:The version 4 format has a more detailed block data format
 this leads to more complicated parser.
 """
-function readGmsh2D_v4(filename::String, options::MeshImportOptions)
+function read_Gmsh_2D_v4(filename::String, options::MeshImportOptions)
     @unpack grouping, remap_group_name = options
 
     if !isfile(filename)
@@ -119,7 +119,7 @@ function readGmsh2D_v4(filename::String, options::MeshImportOptions)
 
 
     if gmsh_version == 4.1
-        @info "reading gmsh file with legacy ($gmsh_version) format"
+        @info "reading Gmsh file with legacy ($gmsh_version) format"
     else
         @warn "Gmsh file version is: $gmsh_version consider using a different parsing fuction for this file format"
     end
@@ -231,25 +231,25 @@ end
 """
 For brevity while grouping is the only supported feature this allows
 for simpler code
-    example: VXY, EToV, grouping = readGmsh2D_v4("file.msh",true)
-    example: VXY, EToV = readGmsh2D_v4("file.msh",false)
+    example: VXY, EToV, grouping = read_Gmsh_2D_v4("file.msh",true)
+    example: VXY, EToV = read_Gmsh_2D_v4("file.msh",false)
 """
-function readGmsh2D_v4(filename::String, groupOpt::Bool=false, remap_group_name::Bool=false)
+function read_Gmsh_2D_v4(filename::String, groupOpt::Bool=false, remap_group_name::Bool=false)
     options = MeshImportOptions(groupOpt, remap_group_name)
-    return readGmsh2D_v4(filename, options)
+    return read_Gmsh_2D_v4(filename, options)
 end
 
 """
-function readGmsh2D(filename)
+function read_Gmsh_2D(filename)
 reads triangular GMSH 2D file format 2.2 0 8. returns (VX, VY), EToV
 # Examples
 ```julia
-VXY, EToV = readGmsh2D("eulerSquareCylinder2D.msh")
+VXY, EToV = read_Gmsh_2D("eulerSquareCylinder2D.msh")
 ```
 
 https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format-version-2-_0028Legacy_0029
 """
-function readGmsh2D(filename::String)
+function read_Gmsh_2D(filename::String)
     f = open(filename)
     lines = readlines(f)
 
@@ -257,9 +257,9 @@ function readGmsh2D(filename::String)
     version, _, dataSize = split(lines[format_line])
     gmsh_version = parse(Float64, version)
     if gmsh_version == 2.2
-        @info "reading gmsh file with legacy ($gmsh_version) format"
+        @info "reading Gmsh file with legacy ($gmsh_version) format"
     elseif gmsh_version == 4.1
-        @assert "This parsing function is not compatable with gmsh version $gmsh_version"
+        @assert "This parsing function is not compatable with Gmsh version $gmsh_version"
     else
         @warn "Gmsh file version is: $gmsh_version consider using a different parsing fuction for this file format"
     end
@@ -322,3 +322,7 @@ function correct_negative_Jacobians!((VX, VY), EToV)
     end
     return EToV
 end
+
+# deprecate these in the next major release 
+@deprecate readGmsh2D(filename) read_Gmsh_2D(filename)
+@deprecate readGmsh2D_v4(filename) read_Gmsh_2D_v4(filename)

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -325,4 +325,4 @@ end
 
 # deprecate these in the next major release 
 @deprecate readGmsh2D(filename) read_Gmsh_2D(filename)
-@deprecate readGmsh2D_v4(filename) read_Gmsh_2D_v4(filename)
+@deprecate readGmsh2D_v4(filename, args...) read_Gmsh_2D_v4(filename, args...)

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -323,6 +323,6 @@ function correct_negative_Jacobians!((VX, VY), EToV)
     return EToV
 end
 
-# deprecate these in the next major release 
+# TODO: deprecate these in major release 0.18 or 1.0 (whichever's first)
 @deprecate readGmsh2D(filename) read_Gmsh_2D(filename)
 @deprecate readGmsh2D_v4(filename, args...) read_Gmsh_2D_v4(filename, args...)

--- a/test/boundary_util_tests.jl
+++ b/test/boundary_util_tests.jl
@@ -35,16 +35,16 @@
         #test build_periodic_boundary_maps
         rd = RefElemData(Tri(),3);
         
-        VXY, EToV,g = readGmsh2D_v4("testset_Gmsh_meshes/periodicity_mesh_v4.msh",true);
+        VXY, EToV, g = readGmsh2D_v4("testset_Gmsh_meshes/periodicity_mesh_v4.msh",true);
         md = MeshData(VXY, EToV, rd);
-        md_test = make_periodic(md,tol=4e-12)
-        @test md_test.xf[md_test.mapB]!=md.xf[md.mapB]
-        @test md_test.yf[md_test.mapB]!=md.yf[md.mapB]
+        md_test = make_periodic(md, tol=4e-12)
+        @test md_test.xf[md_test.mapB] != md.xf[md.mapB]
+        @test md_test.yf[md_test.mapB] != md.yf[md.mapB]
         
         VXY, EToV = readGmsh2D("testset_Gmsh_meshes/periodicity_mesh_v2.msh");
         md = MeshData(VXY, EToV, rd);
-        md_test = make_periodic(md,tol=4e-12)
-        @test md_test.xf[md_test.mapB]!=md.xf[md.mapB]
-        @test md_test.yf[md_test.mapB]!=md.yf[md.mapB]
+        md_test = make_periodic(md, tol=4e-12)
+        @test md_test.xf[md_test.mapB] != md.xf[md.mapB]
+        @test md_test.yf[md_test.mapB] != md.yf[md.mapB]
     end
 end

--- a/test/gmsh_parse_tests.jl
+++ b/test/gmsh_parse_tests.jl
@@ -97,8 +97,6 @@
             end
         end
     end
-
-    # TODO: avoid the use of stderr.txt, causes issues on Windows
     
     @testset "gmsh version 4.1 file with one data grouping" begin
         file = "testset_Gmsh_meshes/one_group_v4.msh"

--- a/test/gmsh_parse_tests.jl
+++ b/test/gmsh_parse_tests.jl
@@ -4,12 +4,12 @@
 
 @testset "Gmsh" begin 
     @testset "Gmsh reading" begin
-        VXY, EToV = readGmsh2D("testset_Gmsh_meshes/squareCylinder2D.msh")
+        VXY, EToV = read_Gmsh_2D("testset_Gmsh_meshes/squareCylinder2D.msh")
         @test size(EToV) == (3031, 3)
 
         # malpasset data taken from 
         # https://github.com/li12242/NDG-FEM/blob/master/Application/SWE/SWE2d/Benchmark/%40Malpasset2d/mesh/triMesh/malpasset.msh
-        VXY, EToV = readGmsh2D("testset_Gmsh_meshes/malpasset.msh")
+        VXY, EToV = read_Gmsh_2D("testset_Gmsh_meshes/malpasset.msh")
         rd = RefElemData(Tri(), 1)
         md = MeshData(VXY, EToV, rd)
         @test all(md.J .> 0)
@@ -28,9 +28,9 @@
 
             rd = RefElemData(Tri(), approxType, N)
             if version == 2.2
-                VXY, EToV = readGmsh2D("testset_Gmsh_meshes/$file"*".msh");
+                VXY, EToV = read_Gmsh_2D("testset_Gmsh_meshes/$file"*".msh");
             elseif version == 4.1
-                VXY, EToV = readGmsh2D_v4("testset_Gmsh_meshes/$file"*"_v4.msh");
+                VXY, EToV = read_Gmsh_2D("testset_Gmsh_meshes/$file"*"_v4.msh");
             end
             md = MeshData(VXY, EToV, rd)
 
@@ -101,8 +101,8 @@
     @testset "gmsh version 4.1 file with one data grouping" begin
         file = "testset_Gmsh_meshes/one_group_v4.msh"
         if isfile(file)
-            VXY_1, EToV_1 = readGmsh2D_v4(file)
-            VXY_2, EToV_2, group_2 = readGmsh2D_v4(file,true) 
+            VXY_1, EToV_1 = read_Gmsh_2D(file)
+            VXY_2, EToV_2, group_2 = read_Gmsh_2D(file, true) 
             @test VXY_1 == VXY_2 
             @test EToV_1 == EToV_2 
             f = open(file)
@@ -120,8 +120,8 @@
         # suppose such grouping data however is not in the file
         file = "testset_Gmsh_meshes/no_group_v4.msh"
         if isfile(file)
-            VXY_1, EToV_1 = readGmsh2D_v4(file)
-            VXY_2, EToV_2, group_2 = readGmsh2D_v4(file, true) 
+            VXY_1, EToV_1 = read_Gmsh_2D(file)
+            VXY_2, EToV_2, group_2 = read_Gmsh_2D(file, true) 
             @test VXY_1 == VXY_2 
             @test EToV_1 == EToV_2 
             f = open(file)
@@ -137,8 +137,8 @@
     @testset "Compare output between v2.2 and v4.1" begin
         @testset "file:$file" for file in ["mesh_no_pert","pert_mesh","malpasset"]
             if isfile("testset_Gmsh_meshes/$file.msh") && isfile("testset_Gmsh_meshes/$file"*"_v4.msh")
-                VXY_v2, EToV_v2 = readGmsh2D("testset_Gmsh_meshes/$file.msh");
-                VXY_v4, EToV_v4 = readGmsh2D_v4("testset_Gmsh_meshes/$file" * "_v4.msh");
+                VXY_v2, EToV_v2 = read_Gmsh_2D("testset_Gmsh_meshes/$file.msh");
+                VXY_v4, EToV_v4 = read_Gmsh_2D("testset_Gmsh_meshes/$file" * "_v4.msh");
                 @test VXY_v2 == VXY_v4
                 @test EToV_v2 == EToV_v4 
             end


### PR DESCRIPTION
This PR does a few things related to Gmsh triangle mesh readers
1. Introduces `read_Gmsh_2D`, which reads both v2.2 and v4.1 file formats. 
2. Deprecates `readGmsh2D` and `readGmsh2D_v4` in favor of the above (to be removed in a future version)
3. Switches to `read_Gmsh_2D_v2` and `read_Gmsh_2D_v4` internally for clarity