### PR TITLE
remove deprecated `approximationType` `getproperty`

### DIFF
--- a/src/RefElemData.jl
+++ b/src/RefElemData.jl
@@ -134,12 +134,12 @@ end
 
 """
     function RefElemData(elem; N, kwargs...)
-    function RefElemData(elem, approxType; N, kwargs...)
+    function RefElemData(elem, approx_type; N, kwargs...)
 
 Keyword argument constructor for RefElemData (to "label" `N` via `rd = RefElemData(Line(), N=3)`)
 """
 RefElemData(elem; N, kwargs...) = RefElemData(elem, N; kwargs...)
-RefElemData(elem, approxType; N, kwargs...) = RefElemData(elem, approxType, N; kwargs...)
+RefElemData(elem, approx_type; N, kwargs...) = RefElemData(elem, approx_type, N; kwargs...)
 
 # default to Polynomial-type RefElemData
 RefElemData(elem, N::Int; kwargs...) = RefElemData(elem, Polynomial(), N; kwargs...)

--- a/src/RefElemData.jl
+++ b/src/RefElemData.jl
@@ -127,12 +127,6 @@ function Base.getproperty(x::RefElemData{Dim, ElementType, ApproxType}, s::Symbo
         return length(getfield(x, :rstq)[1])
     elseif s==:Nfq
         return length(getfield(x, :rstf)[1])
-
-    # CamlCase will be deprecated in the next breaking release v0.17
-    elseif s==:approximationType
-        @warn "RefElemData property `approximationType` is deprecated and will be removed in v0.17. " * 
-              "Please use `approximation_type` instead."
-        return getfield(x, :approximation_type)
     else
         return getfield(x, s)
     end

--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -76,7 +76,7 @@ include("mesh/simple_meshes.jl")
 export uniform_mesh
 include("mesh/gmsh_utilities.jl")
 export read_Gmsh_2D # unifies v2.2.8 and v4.1 mesh reading
-export readGmsh2D, readGmsh2D_v4 # TODO: deprecate these
+export readGmsh2D, readGmsh2D_v4 
 export MeshImportOptions 
 include("mesh/hohqmesh_utilities.jl")
 export read_HOHQMesh

--- a/test/reference_elem_tests.jl
+++ b/test/reference_elem_tests.jl
@@ -15,9 +15,6 @@
             @test invoke(inverse_trace_constant, Tuple{RefElemData},rd) ≈ inverse_trace_constant(rd)
         end
         @test propertynames(rd)[1] == :element_type
-
-        # test for deprecated CamlCase approximationType usage
-        @test rd.approximationType == rd.approximation_type
     end
 
     @testset "Triangle" begin


### PR DESCRIPTION
We switched to snake case `approximation_type` but kept the old CamlCase `approximationType` as a property. 