### PR TITLE
Switch to concatenated nonconforming interface treatment

### DIFF
--- a/src/nonconforming.jl
+++ b/src/nonconforming.jl
@@ -22,7 +22,7 @@ uf = reshape(rd.Vf * u, :, num_total_faces)
 u_mortar = reshape(mortar_interpolation_matrix * uf[:, nonconforming_faces], :, 2 * length(nonconforming_faces))
 
 # construct interior (uM = u⁻ "minus") values and exterior (uP = u⁺ "plus") values
-uM = hcat(uf, u_mortar)
+uM = hcat(uf, u_mortar) # uM = both element faces and mortar faces
 uP = uM[md.mapP]
 ```
 The `mortar_projection_matrix` similarly maps values from 2 mortar faces back to values on the 

--- a/test/noncon_mesh_tests.jl
+++ b/test/noncon_mesh_tests.jl
@@ -12,8 +12,8 @@
 
     # interpolate faces to mortars (`uf` denotes mortar faces for `NonConformingMesh` types)
     (; nonconforming_faces, mortar_interpolation_matrix) = md.mesh_type
-
-    u_mortar = reshape(mortar_interpolation_matrix * uf[:, nonconforming_faces], :, num_mortars_per_face(rd) * length(nonconforming_faces))
+    u_mortar = reshape(mortar_interpolation_matrix * uf[:, nonconforming_faces], :, 
+                       num_mortars_per_face(rd) * length(nonconforming_faces))
     
     # construct interior (uM = u⁻ "minus") values and exterior (uP = u⁺ "plus") values
     uM = hcat(uf, u_mortar)

--- a/test/noncon_mesh_tests.jl
+++ b/test/noncon_mesh_tests.jl
@@ -13,7 +13,7 @@
     # interpolate faces to mortars (`uf` denotes mortar faces for `NonConformingMesh` types)
     (; nonconforming_faces, mortar_interpolation_matrix) = md.mesh_type
 
-    u_mortar = reshape(mortar_interpolation_matrix * uf[:, nonconforming_faces], :, 2 * length(nonconforming_faces))
+    u_mortar = reshape(mortar_interpolation_matrix * uf[:, nonconforming_faces], :, num_mortars_per_face(rd) * length(nonconforming_faces))
     
     # construct interior (uM = u⁻ "minus") values and exterior (uP = u⁺ "plus") values
     uM = hcat(uf, u_mortar)

--- a/test/noncon_mesh_tests.jl
+++ b/test/noncon_mesh_tests.jl
@@ -3,27 +3,22 @@
     rd = RefElemData(Quad(), N=3)
     md = MeshData(NonConformingQuadMeshExample(), rd)
 
-    (; x, y  ) = md
+    (; x, y) = md
     u = @. sin(pi * x) * sin(pi * y)
 
     # interpolate to faces
     num_total_faces = num_faces(rd.element_type) * md.num_elements
-    u_face = reshape(rd.Vf * u, :, num_total_faces)
+    uf = reshape(rd.Vf * u, :, num_total_faces)
 
     # interpolate faces to mortars (`uf` denotes mortar faces for `NonConformingMesh` types)
-    (; conforming_faces, nonconforming_faces, mortar_interpolation_matrix  ) = md.mesh_type
+    (; nonconforming_faces, mortar_interpolation_matrix) = md.mesh_type
 
-    u_mortar = similar(md.xf)
-    view(u_mortar, :, 1:length(conforming_faces)) .= view(u_face, :, conforming_faces)
-    # interpolate to non-conforming faces
-    for (i, f) in enumerate(nonconforming_faces)
-        mortar_face_ids = (1:num_mortars_per_face(rd)) .+ (i-1) * num_mortars_per_face(rd) .+ length(conforming_faces)
-        u_mortar[:, mortar_face_ids] .= reshape(mortar_interpolation_matrix * u_face[:, f], :, num_mortars_per_face(rd))
-    end
-
-    # get exterior values
-    uP = u_mortar[md.mapP]
+    u_mortar = reshape(mortar_interpolation_matrix * uf[:, nonconforming_faces], :, 2 * length(nonconforming_faces))
+    
+    # construct interior (uM = u⁻ "minus") values and exterior (uP = u⁺ "plus") values
+    uM = hcat(uf, u_mortar)
+    uP = uM[md.mapP]
 
     # check that the jumps are zero for continuous u with zero boundary values
-    @test maximum(abs.(uP - u_mortar)) < 100 * eps()
+    @test maximum(abs.(uP - uM)) < 100 * eps()
 end


### PR DESCRIPTION
For non-conforming meshes, the interface node map `mapP` currently operates on a matrix whose columns correspond to unique mortar faces. This PR changes this so that `mapP` operates on a matrix whose columns correspond to both element faces (including un-split conforming faces) and mortar faces (which are concatenated after the element faces). 

This should simplify the data structures for adaptivity.