### PR TITLE
allow HDF5.jl v0.17 and bump version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StartUpDG"
 uuid = "472ebc20-7c99-4d4b-9470-8fde4e9faa0f"
 authors = ["Jesse Chan", "Yimin Lin"]
-version = "0.17.5"
+version = "0.17.6"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
@@ -26,7 +26,7 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 [compat]
 ConstructionBase = "1"
 FillArrays = "0.13, 1"
-HDF5 = "0.16"
+HDF5 = "0.16, 0.17"
 Kronecker = "0.5"
 NodesAndModes = "0.9"
 PathIntersections = "0.1"


### PR DESCRIPTION
It would be great to be able to use v0.17 of HDF5.jl in Trixi.jl. Xref https://github.com/trixi-framework/Trixi.jl/pull/1504