### PR TITLE
Fix tolerances for high `N` tet elements

### DIFF
--- a/src/MeshData.jl
+++ b/src/MeshData.jl
@@ -357,7 +357,9 @@ function MeshData(VX, VY, VZ, EToV, rd::RefElemData{3}; is_periodic=(false, fals
                   periodicity)
 
     if any(is_periodic)
-        md = make_periodic(md, is_periodic)
+        # loosen the tolerance if N >> 1
+        tol = length(rd.r) * 100 * eps() 
+        md = make_periodic(md, is_periodic; tol)
     end
 
     return md

--- a/src/RefElemData_polynomial.jl
+++ b/src/RefElemData_polynomial.jl
@@ -129,7 +129,8 @@ function RefElemData(elem::Union{Tet, Hex},
 
     # Construct matrices on reference elements
     r, s, t = nodes(elem, N)
-    Fmask = hcat(find_face_nodes(elem, r, s, t)...)
+    tol = 1e2 * eps() * length(r) # loosen the tolerance if N >> 1
+    Fmask = hcat(find_face_nodes(elem, r, s, t, tol)...)
     VDM, Vr, Vs, Vt = basis(elem, N, r, s, t)
     Dr, Ds, Dt = (A -> A / VDM).((Vr, Vs, Vt))
 


### PR DESCRIPTION
At high `N` (e.g., `N > 10`) the tolerances were sometimes too tight. This PR scales the tolerance with the number of nodes. 