### PR TITLE
Fix `Fmask` calculation for `SBP` approx type on `Hex` elements

### DIFF
--- a/src/RefElemData_SBP.jl
+++ b/src/RefElemData_SBP.jl
@@ -26,6 +26,21 @@ function RefElemData(elementType::Union{Quad, Hex}, approxType::SBP{TensorProduc
                      Polynomial(TensorProductQuadrature(gauss_lobatto_quad(0, 0, N))), 
                      N; kwargs...)
 
+    println("Brute force Fmask determination")
+    # manually determine Fmask so that rd.rf = rd.r[rd.Fmask], ...
+    new_Fmask = copy(rd.Fmask)    
+    for fid in eachindex(rd.rf)
+        rstf = SVector(getindex.(rd.rstf, fid))
+        for i in eachindex(rd.r)
+            rst = SVector(getindex.(rd.rst, i))
+            if rstf ≈ rst
+                new_Fmask[fid] = i
+                break
+            end
+        end
+    end
+    rd = @set rd.Fmask = new_Fmask;                     
+
     rd = @set rd.Vf = droptol!(sparse(rd.Vf), tol)
     rd = @set rd.LIFT = Diagonal(rd.wq) \ (rd.Vf' * Diagonal(rd.wf)) # TODO: make this more efficient with LinearMaps?
 

--- a/src/RefElemData_SBP.jl
+++ b/src/RefElemData_SBP.jl
@@ -26,8 +26,7 @@ function RefElemData(elementType::Union{Quad, Hex}, approxType::SBP{TensorProduc
                      Polynomial(TensorProductQuadrature(gauss_lobatto_quad(0, 0, N))), 
                      N; kwargs...)
 
-    println("Brute force Fmask determination")
-    # manually determine Fmask so that rd.rf = rd.r[rd.Fmask], ...
+    # brute-force determine Fmask so that rd.rf = rd.r[rd.Fmask], etc.
     new_Fmask = copy(rd.Fmask)    
     for fid in eachindex(rd.rf)
         rstf = SVector(getindex.(rd.rstf, fid))

--- a/test/multidim_sbp_tests.jl
+++ b/test/multidim_sbp_tests.jl
@@ -47,6 +47,9 @@
     @testset "TensorProductLobatto Hex" begin
         rd = RefElemData(Hex(),SBP(),N)
         @test propertynames(rd)[1] == :element_type
+        @test rd.rf == rd.r[rd.Fmask]
+        @test rd.sf == rd.s[rd.Fmask]
+        @test rd.tf == rd.t[rd.Fmask]
         @test rd.t == rd.rst[3]
         @test rd.tf == rd.rstf[3]    
         @test rd.tq == rd.rstq[3]


### PR DESCRIPTION
Previously, `rd.r[rd.Fmask]` was not equal to `rd.rf` for `SBP` approximation types. This assumption only makes sense for `SBP` approximation types, since for collocated volume and surface nodes, the surface nodes can be extracted from the volume nodes. 

This could be considered a breaking release. However, since this should have been the original behavior and since it addresses some failing tests in https://github.com/trixi-framework/Trixi.jl/pull/2001, I plan to release it as a bug fix instead of a breaking release.