### PR TITLE
switch to using CaratheodoryPruning.jl 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Jesse Chan", "Yimin Lin"]
 version = "1.1.5"
 
 [deps]
+CaratheodoryPruning = "ab320bfc-8242-4797-bfc4-9370c33880e7"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -2,6 +2,7 @@ module StartUpDG
 
 using Reexport: @reexport
 
+using CaratheodoryPruning: CaratheodoryPruning
 using ConstructionBase: ConstructionBase
 using FillArrays: Fill
 using HDF5: h5open # used to read in SBP triangular node data

--- a/src/cut_cell_meshes.jl
+++ b/src/cut_cell_meshes.jl
@@ -332,7 +332,7 @@ function construct_cut_volume_quadrature(N, cutcells, physical_frame_elements;
         # perform Caratheodory pruning
         Vtarget = vandermonde(physical_frame_elements[e], target_degree, vec(xq), vec(yq))
         w = vec(wJq)
-        w_pruned, inds = StartUpDG.caratheodory_pruning_qr(Vtarget, w)
+        w_pruned, inds = CaratheodoryPruning.caratheodory_pruning(Vtarget, w)
 
         # test exactness of the pruned quadrature rule if applicable
         if target_degree >= 2 * N


### PR DESCRIPTION
Currently, we use `StartUpDG.caratheodory_pruning_qr`, which is slow when the matrix is sufficiently large.  