### PR TITLE
Clean up visualization

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(
         "`MeshData`" => "MeshData.md",
         "Example: computing DG derivatives" => "ex_dg_deriv.md",
         "Additional mesh types" => "more_meshes.md",
+        "Visualization" => "visualization.md",        
         "Timestepping" => "tstep_usage.md",
         "Reference" => "index_refs.md",
     ]

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -1,0 +1,26 @@
+# Basic visualization
+
+StartUpDG.jl has utilities for exporting fields to VTK for visualization using [Paraview](https://www.paraview.org/). Recall that StartUpDG.jl represents solution fields as `num_points` by `num_elements` arrays, where `num_points = rd.Np` and `num_elements = md.num_elements`. We can export data to a `.vtu` file using `export_to_vtk` as follows:
+```julia
+rd = RefElemData(Tri(), 3)
+md = MeshData(uniform_mesh(Tri(), 2), rd)
+(; x, y) = md
+u = @. (x + y)^2
+v = @. x^2 + y^2
+vtu_name = export_to_vtk(rd, md, [u, v], "uv.vtu")
+```
+If we wish to provide labels for each field, we can do so using a `Dict`:
+```julia
+rd = RefElemData(Tri(), 3)
+md = MeshData(uniform_mesh(Tri(), 2), rd)
+(; x, y) = md
+u = @. (x + y)^2
+v = @. x^2 + y^2
+vtu_name = export_to_vtk(rd, md, Dict("u" => u, "v" => v), "uv.vtu")
+```
+By default, `export_to_vtk` assumes the solution is represented using values at interpolation nodes and interpolates the values to equispaced nodes on each element. Setting the keyword argument `equi_dist_nodes` bypasses this interpolation step, for example
+```julia
+vtu_name = export_to_vtk(rd, md, Dict("u" => u, "v" => v), "uv.vtu"; equi_dist_nodes=false)
+```
+
+

--- a/src/StartUpDG.jl
+++ b/src/StartUpDG.jl
@@ -93,8 +93,8 @@ export read_HOHQMesh
 
 # Plots.jl recipes for meshes
 include("mesh/vtk_helper.jl")
-include("mesh/mesh_visualization.jl")
-export VertexMeshPlotter, MeshPlotter, MeshData_to_vtk
+include("mesh/visualization.jl")
+export VertexMeshPlotter, MeshPlotter, MeshData_to_vtk, export_to_vtk
 
 # Triangulate interfaces and pre-built meshes
 include("mesh/triangulate_utils.jl")

--- a/src/mesh/visualization.jl
+++ b/src/mesh/visualization.jl
@@ -83,8 +83,8 @@ Translate the given mesh into a vtk-file.
 `write_data`, flag if data should be written or not (e.g., if data is not written, only the mesh will be saved as output)
 `equi_dist_nodes` flag if points should be interpolated to equidstant nodes
 """
-function MeshData_to_vtk(md::MeshData, rd::RefElemData{DIM}, data, dataname, filename, 
-                         write_data = false, equi_dist_nodes = true) where {DIM}
+function MeshData_to_vtk(md::MeshData, rd::RefElemData, data, dataname, filename, 
+                         write_data = false, equi_dist_nodes = true) 
                          
     # Compute the permutation between the StartUpDG order of points and vtk
     perm = SUD_to_vtk_order(rd)

--- a/src/mesh/visualization.jl
+++ b/src/mesh/visualization.jl
@@ -73,7 +73,7 @@ RecipesBase.@recipe function f(m::VertexMeshPlotter{2})
 end
 
 """
-    MeshData_to_vtk(md, rd, data, dataname, datatype, filename, write_data = false, equi_dist_nodes = true)
+    MeshData_to_vtk(md, rd, data, dataname, filename, write_data = false, equi_dist_nodes = true)
 
 Translate the given mesh into a vtk-file.
 `md` holds a `MeshData` object
@@ -114,7 +114,7 @@ function MeshData_to_vtk(md::MeshData, rd::RefElemData{DIM}, data, dataname, fil
 end
 
 """
-MeshData_to_vtk(md, rd, data, dataname, datatype, filename, write_data = false, equi_dist_nodes = true)
+MeshData_to_vtk(md, rd, data, dataname, filename, write_data = false, equi_dist_nodes = true)
 
 Translate the given mesh into a vtk-file.
 `md` holds a `MeshData` object

--- a/test/write_vtk_tests.jl
+++ b/test/write_vtk_tests.jl
@@ -65,6 +65,9 @@
 
     @testset "TensorProduct VTKWriter" begin
         @testset "Degree ($tri_N, $line_N)" for tri_N in 2, line_N in 3
+            function quad(x, y)
+                return (x + y)^2
+            end
             line = RefElemData(Line(), line_N)
             tri  = RefElemData(Tri(), tri_N)
             tensor = TensorProductWedge(tri, line)

--- a/test/write_vtk_tests.jl
+++ b/test/write_vtk_tests.jl
@@ -35,7 +35,8 @@
             # ======= check `export_to_vtk` interfaces
             
             # copy of MeshData_to_vtk but with rd, md reversed for consistency
-            vtu_name = export_to_vtk(rd, md, pdata, ["(x+y)^2"], filename)
+            vtu_name = export_to_vtk(rd, md, pdata, ["(x+y)^2"], filename; 
+                                     equi_dist_nodes=false)
             @test vtu_name[1] == check
             rm(check) # remove created file after test is done
 
@@ -46,7 +47,7 @@
 
             # with data/dataname specified via Dict
             data = quad.(interpolate * md.x, interpolate * md.y)
-            vtu_name = export_to_vtk(rd, md, Dict("(x+y)^2" => data), filename)            
+            vtu_name = export_to_vtk(rd, md, Dict("(x+y)^2" => data), filename)
             @test vtu_name[1] == check
             rm(check) # remove created file after test is done
         end

--- a/test/write_vtk_tests.jl
+++ b/test/write_vtk_tests.jl
@@ -1,9 +1,5 @@
 @testset "VTK tests" begin
 
-    function quad(x, y)
-        return (x + y)^2
-    end
-
     # test expected output of `vtk_order`
     deg_one_order(::Tri) = permutedims(hcat(nodes(Tri(), 1)...))
     deg_zero_order(::Tri) = [-1.0; -1.0]
@@ -21,16 +17,36 @@
 
 
     @testset "VTKWriter test for $elem" for elem in [Tri(), Quad(), Hex(), Wedge(), Tet()]
-        N = 2 # test only N=2 for CI time
         @testset "Write Mesh" begin
-            rd = RefElemData(elem, N)
+            function quad(x, y)
+                return (x + y)^2
+            end
+            rd = RefElemData(elem, 2) # test only N=2 for CI time
             md = MeshData(uniform_mesh(elem, 2)..., rd)
             interpolate = vandermonde(rd.element_type, rd.N, equi_nodes(rd.element_type, rd.N)...) / rd.VDM
             pdata = [quad.(interpolate * md.x, interpolate * md.y)]
-            filename = replace(string(elem), "()" => "") * "_" * string(N)
+            filename = replace(string(elem), "()" => "") * "_" * string(rd.N)
             check = filename * ".vtu"
             # Todo: Can we implement a better check?
             vtu_name = MeshData_to_vtk(md, rd, pdata, ["(x+y)^2"], filename, true)
+            @test vtu_name[1] == check
+            rm(check) # remove created file after test is done
+
+            # ======= check `export_to_vtk` interfaces
+            
+            # copy of MeshData_to_vtk but with rd, md reversed for consistency
+            vtu_name = export_to_vtk(rd, md, pdata, ["(x+y)^2"], filename)
+            @test vtu_name[1] == check
+            rm(check) # remove created file after test is done
+
+            # without filename specified
+            vtu_name = export_to_vtk(rd, md, pdata, filename)            
+            @test vtu_name[1] == check
+            rm(check) # remove created file after test is done
+
+            # with data/dataname specified via Dict
+            data = quad.(interpolate * md.x, interpolate * md.y)
+            vtu_name = export_to_vtk(rd, md, Dict("(x+y)^2" => data), filename)            
             @test vtu_name[1] == check
             rm(check) # remove created file after test is done
         end
@@ -48,14 +64,14 @@
     end
 
     @testset "TensorProduct VTKWriter" begin
-        @testset "Degree ($tri_grad, $line_grad)" for tri_grad in 2, line_grad in 3
-            line = RefElemData(Line(), line_grad)
-            tri  = RefElemData(Tri(), tri_grad)
+        @testset "Degree ($tri_N, $line_N)" for tri_N in 2, line_N in 3
+            line = RefElemData(Line(), line_N)
+            tri  = RefElemData(Tri(), tri_N)
             tensor = TensorProductWedge(tri, line)
             rd = RefElemData(Wedge(), tensor)
             md = MeshData(uniform_mesh(Wedge(), 2)..., rd)
             pdata = [quad.(md.x, md.y)]
-            filename = "TensorProductWedge" * "_" * string(tri_grad) * "_" * string(line_grad)
+            filename = "TensorProductWedge" * "_" * string(tri_N) * "_" * string(line_N)
             check = filename * ".vtu"
             # Todo: Can we implement a better check?
             vtu_name = MeshData_to_vtk(md, rd, pdata, ["(x+y)^2"], filename, true, true)


### PR DESCRIPTION
Add documentation, fix docstrings.

Adds `export_to_vtk` as an alternative to `MeshData_to_vtk`; I think the new name is more descriptive. Added also some convenience methods which specialize on the type of `pdata`. 