### PR TITLE
add `MeshData(meshIO::TriangulateIO, rd)` interface

### DIFF
--- a/docs/src/MeshData.md
+++ b/docs/src/MeshData.md
@@ -77,9 +77,8 @@ More generally, one can create a copy of a `MeshData` with certain fields modifi
 StartUpDG.jl also includes additional utilities based on Triangulate.jl for creating and visualizing meshes. Several pre-defined geometries are included in StartUpDG.jl. A few examples are `SquareDomain`, `RectangularDomainWithHole`, `Scramjet`, and `CircularDomain`. See [`triangulate_example_meshes.jl`](https://github.com/jlchan/StartUpDG.jl/blob/main/src/mesh/triangulate_example_meshes.jl) for a more complete list and field arguments. These can each be called using `triangulate_domain`, for example the following code will create a mesh of a scramjet:
 ```julia
 meshIO = triangulate_domain(Scramjet())
-(VX, VY), EToV = triangulateIO_to_VXYEToV(meshIO)
 rd = RefElemData(Tri(), 7)
-md = MeshData((VX, VY), EToV, rd)
+md = MeshData(meshIO, rd)
 ```
 A quick plot of the face nodes via 
 ```julia

--- a/src/mesh/triangulate_utils.jl
+++ b/src/mesh/triangulate_utils.jl
@@ -1,5 +1,16 @@
 
 """
+    function MeshData(io::TriangulateIO, rd::RefElemData; kwargs...)
+
+Convenience routine to construct a MeshData object given a TriangulateIO object.
+"""
+function MeshData(meshIO::TriangulateIO, rd::RefElemData; kwargs...)
+    (VX, VY), EToV = triangulateIO_to_VXYEToV(meshIO)    
+    md = MeshData((VX, VY), EToV, rd)
+    return md
+end
+
+"""
     function Triangulate.triangulate(triin::TriangulateIO, maxarea, minangle=20)
 
 Convenience routine to avoid writing out `@sprintf` each time. Returns a `TriangulateIO` object.

--- a/src/state_redistribution.jl
+++ b/src/state_redistribution.jl
@@ -139,6 +139,16 @@ struct StateRedistribution{TP, TN, TE, TO, TU}
     u_tmp::TU # temporary storage for operations
 end
 
+"""
+    function StateRedistribution(rd::RefElemData{2, Quad}, 
+        md::MeshData{2, <:CutCellMesh}; solution_eltype=Float64)
+
+Constructs a state redistribution instance `srd`, which can be applied to a DG solution via
+`apply!(u, srd::StateRedistribution)` or `srd(u)`. 
+
+Note that, by default, the constructor assumes that the solution `u` has eltype `Float64`; if 
+this is not the case, then `solution_eltype` should be specified in the constructor.
+"""
 function StateRedistribution(rd::RefElemData{2, Quad}, md::MeshData{2, <:CutCellMesh}; solution_eltype=Float64)
     (; physical_frame_elements) = md.mesh_type
 

--- a/test/triangulate_tests.jl
+++ b/test/triangulate_tests.jl
@@ -11,9 +11,11 @@ mean(x) = sum(x) / length(x)
 
     @testset "Triangulate utils/example meshes" begin
         # test triangulate
-        meshIO = triangulate_domain(SquareDomain())
+        meshIO = triangulate_domain(SquareDomain())        
         rd = RefElemData(Tri(), 2)
         md = MeshData(meshIO, rd)
+
+        (VX, VY), EToV = triangulateIO_to_VXYEToV(meshIO)
         @test size(EToV, 1) == md.num_elements == 620
         @test length(VX) == length(VY) == 338
         @test sort(unique(get_node_boundary_tags(meshIO, rd, md))) == [0, 1, 2, 3, 4]

--- a/test/triangulate_tests.jl
+++ b/test/triangulate_tests.jl
@@ -12,9 +12,8 @@ mean(x) = sum(x) / length(x)
     @testset "Triangulate utils/example meshes" begin
         # test triangulate
         meshIO = triangulate_domain(SquareDomain())
-        (VX, VY), EToV = triangulateIO_to_VXYEToV(meshIO)
         rd = RefElemData(Tri(), 2)
-        md = MeshData((VX, VY), EToV, rd)
+        md = MeshData(meshIO, rd)
         @test size(EToV, 1) == md.num_elements == 620
         @test length(VX) == length(VY) == 338
         @test sort(unique(get_node_boundary_tags(meshIO, rd, md))) == [0, 1, 2, 3, 4]


### PR DESCRIPTION
Add a convenience interface for `MeshData` to accept `meshIO` instances instead of vertex coordinates. 