### PR TITLE
Add `allow_reresolve: false` in downgrade action

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -28,3 +28,5 @@ jobs:
           skip: Pkg,TOML
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false


### PR DESCRIPTION
There is one more issue with the downgrade action: You need to disallow reresolving during the tests. Otherwise everything the Resolver.jl just did, will be undone and all the newest versions will be installed again making the downgrade action meaningless, cf. https://github.com/julia-actions/julia-downgrade-compat/pull/18.