### PR TITLE
Cut Meshes: Bug fix for scaling and sampling

### DIFF
--- a/src/cut_cell_meshes.jl
+++ b/src/cut_cell_meshes.jl
@@ -341,6 +341,8 @@ function construct_cut_volume_quadrature(N, cutcells, physical_frame_elements;
             @assert norm(V' * Diagonal(w) * V - V' * Diagonal(w_pruned) * V) < 100 * eps()
         end
 
+        # the number of pruned nodes can be smaller than Np_target; if so, we simply pad with some extra points with zero weight
+        # TODO: turn off the flag for trimming extra points in CaratheodoryPruning.jl
         if length(inds) < Np_target
             ind_dest = 1:length(inds)
             @. xq_pruned[ind_dest, e]  = xq[inds]

--- a/src/cut_cell_meshes.jl
+++ b/src/cut_cell_meshes.jl
@@ -95,7 +95,7 @@ function generate_sampling_points(objects, elem, Np_target::Int, N_sampled::Int)
     r_sampled, s_sampled = equi_nodes(Quad(), N_sampled) # oversampled nodes
 
     # map sampled points to the background Cartesian cell
-    x_sampled, y_sampled = map_nodes_to_background_cell(elem, r_sampled, s_sampled)
+    x_sampled, y_sampled = map_nodes_to_cutcell_boundingbox(elem, r_sampled, s_sampled)
     is_in_domain = fill(true, length(x_sampled))
     for (index, point) in enumerate(zip(x_sampled, y_sampled))
         is_in_domain[index] = !any(map(obj -> PathIntersections.is_contained(obj, point), objects))
@@ -106,7 +106,7 @@ function generate_sampling_points(objects, elem, Np_target::Int, N_sampled::Int)
 
         N_sampled *= 2 # double degree of sampling
         r_sampled, s_sampled = equi_nodes(Quad(), N_sampled) # oversampled nodes
-        x_sampled, y_sampled = map_nodes_to_background_cell(elem, r_sampled, s_sampled)
+        x_sampled, y_sampled = map_nodes_to_cutcell_boundingbox(elem, r_sampled, s_sampled)
 
         # check if all the points are in all the objects
         is_in_domain = fill(true, length(x_sampled))
@@ -295,6 +295,7 @@ We set `target_degree` to `2 * N - 1` by default, which is sufficient to
 ensure that ∫du/dx * v is integrated exactly so that integration by parts
 holds under the generated cut cell quadrature. 
 """
+# TODO: time this function
 function construct_cut_volume_quadrature(N, cutcells, physical_frame_elements; 
                                          target_degree = 2 * N - 1)
 
@@ -340,9 +341,21 @@ function construct_cut_volume_quadrature(N, cutcells, physical_frame_elements;
             @assert norm(V' * Diagonal(w) * V - V' * Diagonal(w_pruned) * V) < 100 * eps()
         end
 
-        @. xq_pruned[:, e] = xq[inds]
-        @. yq_pruned[:, e] = yq[inds]
-        @. wJq_pruned[:, e] = w_pruned[inds]
+        if length(inds) < Np_target
+            ind_dest = 1:length(inds)
+            @. xq_pruned[ind_dest, e]  = xq[inds]
+            @. yq_pruned[ind_dest, e]  = yq[inds]
+            @. wJq_pruned[ind_dest, e] = w_pruned[inds]
+
+            ind_remainder = length(inds)+1:Np_target
+            xq_pruned[ind_remainder, e]  .= xq_pruned[1,e]
+            yq_pruned[ind_remainder, e]  .= yq_pruned[1,e]
+            wJq_pruned[ind_remainder, e] .= 0.0
+        else
+            @. xq_pruned[:, e] = xq[inds]
+            @. yq_pruned[:, e] = yq[inds]
+            @. wJq_pruned[:, e] = w_pruned[inds]
+        end
     end
     return xq_pruned, yq_pruned, wJq_pruned
 end
@@ -508,12 +521,16 @@ function construct_physical_frame_elements(region_flags, vx, vy, cutcells)
 
     physical_frame_elements = typeof(PhysicalFrame())[] # populate this as we iterate through cut cells
     e = 1
+    s_sampling = 0:0.001:1
     for ex in axes(region_flags, 1), ey in axes(region_flags, 2)
         if StartUpDG.is_cut(region_flags[ex, ey])
 
             # get extremal points (vertices) of the cut cell
             cutcell = cutcells[e]
             coordinates = cutcell.(cutcell.stop_pts[1:end-1])
+            stop_pts = cutcell.(cutcell.stop_pts[1:end-1])
+            boundary_sample_pts = cutcell.(s_sampling)
+            coordinates = [stop_pts; boundary_sample_pts]
 
             # store vertex nodes and coordinates of background Cartesian cell
             physical_frame_element = 

--- a/src/physical_frame_basis.jl
+++ b/src/physical_frame_basis.jl
@@ -24,6 +24,20 @@ end
 # defaults to 2D for now
 PhysicalFrame() = PhysicalFrame(Val{2}())
 
+function get_shifting_and_scaling_cg(x,y)
+    shifting = SVector(mean(x), mean(y))
+    scaling = SVector( 1 / maximum(abs.(x .- shifting[1])), 1 / maximum(abs.(y .- shifting[2])) )
+
+    return shifting, scaling
+end
+
+function get_shifting_and_scaling_maxfill(x,y)
+    scaling = SVector(map(x -> 2 / (x[2] - x[1]), (extrema(x), extrema(y))))
+    shifting = SVector( mean(extrema(x)), mean(extrema(y)) )
+
+    return shifting, scaling
+end
+
 # default shifting and scaling
 function PhysicalFrame(ndims::Val{2}) 
     shifting = SVector(0.0, 0.0)
@@ -33,14 +47,12 @@ function PhysicalFrame(ndims::Val{2})
 end
 
 function PhysicalFrame(x, y)
-    shifting = SVector(mean(x), mean(y))
-    scaling = SVector(map(x -> 2 / (x[2] - x[1]), (extrema(x), extrema(y))))
+    shifting, scaling = get_shifting_and_scaling_cg(x,y)
     return PhysicalFrame(shifting, scaling, nothing)
 end
 
 function PhysicalFrame(x, y, vx, vy)
-    shifting = SVector(mean(x), mean(y))
-    scaling = SVector(map(x -> 2 / (x[2] - x[1]), (extrema(x), extrema(y))))
+    shifting, scaling = get_shifting_and_scaling_cg(x,y)
     vxyz = (vx, vy)
     return PhysicalFrame(shifting, scaling, vxyz)
 end
@@ -134,7 +146,7 @@ to `elem`, with points inside of `curve` removed.
 function NodesAndModes.equi_nodes(elem::PhysicalFrame{2}, curve, N)
     (; vxyz ) = elem
     r, s = equi_nodes(Quad(), N)
-    x, y = map_nodes_to_background_cell(elem, r, s)
+    x, y = map_nodes_to_cutcell_boundingbox(elem, r, s)
     ids = .!PathIntersections.is_contained.(curve, zip(x, y))
     return x[ids], y[ids]
 end
@@ -145,6 +157,14 @@ function map_nodes_to_background_cell(elem::PhysicalFrame{2}, r, s)
     dx, dy = diff(vx), diff(vy)
     x = @. 0.5 * (1 + r) * dx + vx[1]
     y = @. 0.5 * (1 + s) * dy + vy[1]
+    return x, y
+end
+
+function map_nodes_to_cutcell_boundingbox(elem::PhysicalFrame{2}, r, s)
+    (; shifting, scaling ) = elem 
+    
+    x = @. r / scaling[1] + shifting[1]
+    y = @. s / scaling[2] + shifting[2]
     return x, y
 end
 

--- a/src/physical_frame_basis.jl
+++ b/src/physical_frame_basis.jl
@@ -47,7 +47,7 @@ function PhysicalFrame(ndims::Val{2})
 end
 
 function PhysicalFrame(x, y)
-    shifting, scaling = get_shifting_and_scaling_cg(x,y)
+    shifting, scaling = get_shifting_and_scaling_centroid(x,y)
     return PhysicalFrame(shifting, scaling, nothing)
 end
 

--- a/src/physical_frame_basis.jl
+++ b/src/physical_frame_basis.jl
@@ -24,7 +24,7 @@ end
 # defaults to 2D for now
 PhysicalFrame() = PhysicalFrame(Val{2}())
 
-function get_shifting_and_scaling_cg(x,y)
+function get_shifting_and_scaling_centroid(x,y)
     shifting = SVector(mean(x), mean(y))
     scaling = SVector( 1 / maximum(abs.(x .- shifting[1])), 1 / maximum(abs.(y .- shifting[2])) )
 

--- a/src/physical_frame_basis.jl
+++ b/src/physical_frame_basis.jl
@@ -52,7 +52,7 @@ function PhysicalFrame(x, y)
 end
 
 function PhysicalFrame(x, y, vx, vy)
-    shifting, scaling = get_shifting_and_scaling_cg(x,y)
+    shifting, scaling = get_shifting_and_scaling_centroid(x,y)
     vxyz = (vx, vy)
     return PhysicalFrame(shifting, scaling, vxyz)
 end


### PR DESCRIPTION
## Summary of Issues:
1. The shifting and scaling factors for physical frame bases are not calculated correctly.
2. Point sampling in cut elements is extremely inefficient and can cause the program to crash.


## Issues:
### 1) Shifting and Scaling Factor Computation

**Offending functions:**
1. ```PhysicalFrame``` constructors (lns:27-46) in ```src/physical_frame_basis.jl```
2. ```construct_physical_frame_elements``` in ```src/cut_cell_meshes.jl```

**Current functionality:**  The ```PhysicalFrame``` constructors generate shifting and scaling factors to map points on the physical cut element into the reference domain. The shifting is calculated such that the centroid of the cut element (as calculated as the average of points sampled on the cut element's boundary) is mapped to the origin of the reference element and the scaling factor is calculated s.t. the bounding volume of the scaled cut element has sides of length 2 (same as the reference element).

**The Issue:** The shifting and scaling factors are not fully independent of one another: once one is chosen, the other is constrained. You cannot both map the cut element's centroid to the reference element's origin AND have the cut element's bounding volume scaled to a 2 x 2 box. Doing both results in the shifted/scaled cut element not being fully encased in the reference domain; i.e., some mapped points will not be in the reference domain. Additionally, a denser sampling of points on the boundary  is needed to accurately calculate the shifting/scaling factors: currently only the cut element's stop points/corners are being used, which will yield poor shifting/scaling factors for cut elements with outward bulging cut faces.

**Proposed Corrections:**
1. **Point sampling:** We supplement the cut element's boundary's stop points with a fine sampling of points on a cut element's boundaries in ```construct_physical_frame_elements``` in ```src/cut_cell_meshes.jl```. These points are then used to calculate the shifting and scaling factors.

4. **Shifting and scaling factors:**
The calculation of the shifting and scaling factors must be changed. There are two natural approaches:
    1. **centroid -> origin**: compute the shifting factor as before so that the centroid of the cut element is mapped ot the reference domain's origin, but change the scaling factor so that all point in the cut element are mapped to the reference element. The shifting/scaling for this approach are given in the function ```get_shifting_and_scaling_cg``` in ```src/physical_frame_basis.jl```. **This is the change used in this pull request as it is consistent with our cut DG papers**.
    2. **maximize the size of the mapped cut element:** compute the scaling as before so that the cut element's bounding volume is mapped to a 2 x 2 bounding volume, but change the shifting factors so that the 2 x 2 box is contained in the reference domain. This option has the benefit of maximizing the size of the mapped cut element and is implemented in the function ```get_shifting_and_scaling_maxfill``` in ```src/physical_frame_basis.jl```.


### 2) Cut Element Point Sampling
**Offending Functions:** 
1. ```map_nodes_to_background_cell``` in ```src/physical_frame_basis.jl```
2. ```generate_sampling_points``` in ```src/cut_cell_meshes.jl```

**Current functionality:** The function ```generate_sampling_points``` uses ```map_nodes_to_background_cell``` to map a uniform grid of points on the reference element to a cut element's Cartesian background element *using the shifting/scaling indicated by the Cartesian background element*. ```generate_sampling_points``` then tests the mapped points against the cut element's boundary via ```is_contained``` and discards points outside the cut element. 

**The Issue:** When cut elements are extremely small, very few of the mapped points actually reside in the cut element, triggering re-sampling using a finer grid. For sufficiently small cut elements, re-sampling is triggered so many times that sampling may take several minutes to run and in some cases the grid becomes so fine that Julia runs out of memory and crashes.

**Proposed Correction:** An easy fix here is to map points on the reference element to the **bounding volume** of the cut element instead of the Cartesian background element. The shifting and scaling factors used in the construction of the physical frame basis on every cut element define such a bounding volume; these should be used in place of mapping to the Cartesian background element. This new mapping results in a a good number of sampling points within the cut element and is given in the function ```map_nodes_to_cutcell_boundingbox``` in ```src/physical_frame_basis.jl```. It is much more robust and has worked on cut elements with volume ratios as small as 1e-10 and greatly improved the conditioning of the moment-fitting based cut quadrature rules. It is still fallible, but the cases where it fails are harder to trigger; see the appendix of [https://doi.org/10.1016/j.jcp.2024.113528](url) for information on these cases.
