### PR TITLE
add Zenodo DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 [![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://jlchan.github.io/StartUpDG.jl/dev)
 [![Build status](https://github.com/jlchan/StartUpDG.jl/workflows/CI/badge.svg)](https://github.com/jlchan/StartUpDG.jl/actions)
 [![Codecov](https://codecov.io/gh/jlchan/StartUpDG.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/jlchan/StartUpDG.jl)
+[![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12576091.svg)](https://doi.org/10.5281/zenodo.12576091)
 
-This package contains routines to initialize reference element operators, physical mesh arrays, and connectivity arrays for nodal discontinuous Galerkin (DG) methods. It is intended to quick-start the implementation of from-scratch high order time-domain nodal DG solvers for partial differential equations (PDEs), and is designed for flexibility and experimentation. 
+This package contains routines to initialize reference element operators, physical mesh arrays, and connectivity arrays for nodal discontinuous Galerkin (DG) methods. It is intended to quick-start the implementation of from-scratch high order time-domain nodal DG solvers for partial differential equations (PDEs), and is designed for flexibility and experimentation.
 
-The codes are roughly based on *Nodal Discontinuous Galerkin Methods* by Hesthaven and Warburton (2007). The original port from Matlab to Julia was by [Yimin Lin](https://github.com/yiminllin), with subsequent modifications by Jesse Chan and other contributors. 
+The codes are roughly based on *Nodal Discontinuous Galerkin Methods* by Hesthaven and Warburton (2007). The original port from Matlab to Julia was by [Yimin Lin](https://github.com/yiminllin), with subsequent modifications by Jesse Chan and other contributors.
 
 This package is registered and can be installed via `] add StartUpDG` or `using Pkg; Pkg.add("StartUpDG")`.
 
@@ -38,7 +40,11 @@ dudx = (rxJ .* (Dr * u) + sxJ .* (Ds * u)) ./ J
 
 # Contributors
 
-* SBP nodal points were contributed by [Ethan Kubatko](https://sites.google.com/site/chilatosu/ethan-bio) and [Jason Hicken](https://doi.org/10.1007/s10915-020-01154-8). 
-* [Hendrik Ranocha](https://ranocha.de) contributed to array types used in cut-cell and hybrid meshes. 
+* SBP nodal points were contributed by [Ethan Kubatko](https://sites.google.com/site/chilatosu/ethan-bio) and [Jason Hicken](https://doi.org/10.1007/s10915-020-01154-8).
+* [Hendrik Ranocha](https://ranocha.de) contributed to array types used in cut-cell and hybrid meshes.
 * [Mason McCallum](https://github.com/masonamccallum) contributed Gmsh reading capabilities
 * [David Knapp](https://github.com/Davknapp) contributed VTK visualization capabilities and tensor product wedges.
+
+## Referencing
+
+If you use [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl) for your research, please cite it using the DOI [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12576091.svg)](https://doi.org/10.5281/zenodo.12576091).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 This package contains routines to initialize reference element operators, physical mesh arrays, and connectivity arrays for nodal DG methods. The codes are roughly based on *Nodal Discontinuous Galerkin Methods* by Hesthaven and Warburton (2007).
 
-StartUpDG.jl is intended mainly to aid in the implementation of `rhs!` functions for DG discretizations of time-dependent partial differential equations, which can then be used with the OrdinaryDiffEq.jl library to evolve a solution in time. For example, it has been used in most publications since 2020 by the authors [Jesse Chan](https://scholar.google.com/citations?user=rqGSShYAAAAJ&hl=en) and [Yimin Lin](https://scholar.google.com/citations?hl=en&user=yCrSttgAAAAJ), as well as in the following external publications: 
+StartUpDG.jl is intended mainly to aid in the implementation of `rhs!` functions for DG discretizations of time-dependent partial differential equations, which can then be used with the OrdinaryDiffEq.jl library to evolve a solution in time. For example, it has been used in most publications since 2020 by the authors [Jesse Chan](https://scholar.google.com/citations?user=rqGSShYAAAAJ&hl=en) and [Yimin Lin](https://scholar.google.com/citations?hl=en&user=yCrSttgAAAAJ), as well as in the following external publications:
 * [Efficient entropy-stable discontinuous spectral-element methods using tensor-product summation-by-parts operators on triangles and tetrahedra](https://doi.org/10.1016/j.jcp.2024.113360) by Montoya and Zingg (2024).
 * [Injected Dirichlet boundary conditions for general diagonal-norm SBP operators](https://www.researchgate.net/profile/Anita-Gjesteland/publication/374234334_Injected_Dirichlet_boundary_conditions_for_general_diagonal-norm_SBP_operators/links/6515500dcce2460b6c3d6eda/Injected-Dirichlet-boundary-conditions-for-general-diagonal-norm-SBP-operators.pdf) by Gjesteland, Del Rey Fernández, and Svärd (2023).
 
@@ -31,3 +31,7 @@ u = @. exp(-10 * (x^2 + y^2))
 (; rxJ, sxJ, J ) = md
 dudx = (rxJ .* (Dr * u) + sxJ .* (Ds * u)) ./ J
 ```
+
+## Referencing
+
+If you use [StartUpDG.jl](https://github.com/jlchan/StartUpDG.jl) for your research, please cite it using the DOI [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12576091.svg)](https://doi.org/10.5281/zenodo.12576091).


### PR DESCRIPTION
This makes it easier for people who use StartUpDG.jl to find a way how to cite this package. A recent bibtex entry generated from the Zenodo data is

```bibtex
@misc{chan2026startupdg,
  title={StartUpDG.jl: Initializes and sets up reference elements and physical meshes for DG},
  author={Jesse Chan and David Knapp and Mason McCallum and
          Hendrik Ranocha and Christina G Taylor and Philipp Baasch
          and Daniel Doehring and Johannes Markert and Joshua Lampert
          and Tristan Montoya and Vincent X. Wang},
  year={2026},
  howpublished={\url{https://github.com/jlchan/StartUpDG.jl}},
  doi={10.5281/zenodo.19906078}
}
```

Shall I add this as well to make it even easier for people to cite the software?