### PR TITLE
Fix incorrect inverse mass matrix in projection operator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 StartUpDG.jl follows the interpretation of [semantic versioning (semver)](https://julialang.github.io/Pkg.jl/dev/compatibility/#Version-specifier-format-1) used in the Julia ecosystem. Recent changes will be documented in this file for human readability.
 
+## Changes when updating to v1.4.1
+
+#### Fixed
+
+* Fixed an incorrect inverse mass matrix used in the projection operator for `Polynomial(TensorProductQuadrature(...))` approximations on quads and hexes. The 1D inverse mass matrix is now computed as `inv(M1D)` instead of `VDM_1D * VDM_1D'`.
+
 ## Changes when updating to v1.0.0
 
 Most of the major changes are tracked in this [PR](https://github.com/jlchan/StartUpDG.jl/pull/160). Some descriptions of other changes are listed below. 

--- a/src/RefElemData_polynomial.jl
+++ b/src/RefElemData_polynomial.jl
@@ -342,8 +342,8 @@ function RefElemData(elem::Quad,
     VDM_1D = vandermonde(Line(), N, r1D)
     Vq1D = vandermonde(Line(), N, rq1D) / VDM_1D
     invVDM_1D = inv(VDM_1D)
-    invM_1D = VDM_1D * VDM_1D'
     M1D = Vq1D' * diagm(wq1D) * Vq1D
+    invM_1D = inv(M1D)
 
     # form kronecker products of multidimensional matrices to invert/multiply
     VDM = kron(VDM_1D, VDM_1D)
@@ -402,8 +402,8 @@ function RefElemData(elem::Hex,
     VDM_1D = vandermonde(Line(), N, r1D)
     Vq1D = vandermonde(Line(), N, rq1D) / VDM_1D
     invVDM_1D = inv(VDM_1D)
-    invM_1D = VDM_1D * VDM_1D'
     M1D = Vq1D' * diagm(wq1D) * Vq1D
+    invM_1D = inv(M1D)
 
     # form kronecker products of multidimensional matrices to invert/multiply
     # use dense matrix "kron" if N is small.

--- a/test/reference_elem_tests.jl
+++ b/test/reference_elem_tests.jl
@@ -313,25 +313,31 @@ end
     end
 end
 
-# @testset "TensorProductQuadrature on Hex" begin
-#     N = 2
-#     rd = RefElemData(Hex(), TensorProductQuadrature(quad_nodes(Line(), N+1)), N)
-#     rd_ref = RefElemData(Hex(), N; quad_rule_vol=quad_nodes(Hex(), N+1), quad_rule_face=quad_nodes(Quad(), N+1))
+@testset "TensorProductQuadrature matches MultidimensionalQuadrature" begin
+    tol = 1e4 * eps()
+    quad_rules = (gauss_quad, gauss_lobatto_quad)
 
-#     @test typeof(rd) == typeof(RefElemData(Hex(), Polynomial(TensorProductQuadrature(quad_nodes(Line(), N+1))), N))
+    for elem in (Quad(), Hex()), N in (2, 3)
+        for quad_vol in quad_rules, quad_face in quad_rules
+            quad_rule_vol = quad_vol(0, 0, N)
+            quad_rule_face = quad_face(0, 0, N)
+            quad_rule_face_md = elem isa Quad ? quad_rule_face :
+                                StartUpDG.tensor_product_quadrature(face_type(elem), quad_rule_face...)
 
-#     for prop in [:N, :element_type]        
-#         @test getproperty(rd, prop) == getproperty(rd_ref, prop)
-#     end
+            rd_tp = RefElemData(elem,
+                                Polynomial(TensorProductQuadrature(quad_rule_vol)), N;
+                                quad_rule_face = quad_rule_face_md)
+            rd_md = RefElemData(elem,
+                                Polynomial{MultidimensionalQuadrature}(), N;
+                                quad_rule_vol = StartUpDG.tensor_product_quadrature(elem, quad_rule_vol...),
+                                quad_rule_face = quad_rule_face_md)
 
-#     for prop in [:fv, :rst, :rstp, :rstq, :rstf, :nrstJ, :Drst]
-#         @test all(getproperty(rd, prop) .≈ getproperty(rd_ref, prop))
-#     end
-
-#     for prop in [:Fmask, :VDM, :V1, :wq, :Vq, :wf, :Vf, :Vp, :M, :Pq, :LIFT]
-#         @test norm(getproperty(rd, prop) - getproperty(rd_ref, prop)) < 1e4 * eps()
-#     end
-# end
+            @test rd_tp.M ≈ rd_md.M atol=tol
+            @test rd_tp.Pq ≈ rd_md.Pq atol=tol
+            @test rd_tp.LIFT ≈ rd_md.LIFT atol=tol
+        end
+    end
+end
 
 @testset "Tensor product Gauss collocation" begin
     N = 3


### PR DESCRIPTION
## Summary
- Fixes a bug in `RefElemData` construction for `Polynomial(TensorProductQuadrature(...))` approximations on quads and hexes, where the 1D inverse mass matrix was computed as `VDM_1D * VDM_1D'` instead of `inv(M1D)`.
- This incorrect `invM` affected the projection operator `Pq` (and the lifting operator `LIFT`, which uses the same `invM`).
- Adds a `NEWS.md` entry for v1.4.1.

## Test plan
- [x] Construct `RefElemData(Quad(), Polynomial(TensorProductQuadrature(...)), N)` and verify `Pq` projects quadrature data correctly onto polynomial coefficients.
- [x] Repeat for `Hex()` elements.
- [x] Run existing StartUpDG test suite.


Made with [Cursor](https://cursor.com)