### PR TITLE
Enable boundary edge identification for 2D v2.2 Gmsh meshes

### DIFF
--- a/mesh_labeling_import.jl
+++ b/mesh_labeling_import.jl
@@ -1,0 +1,19 @@
+using StartUpDG
+
+(VX, VY), EToV, edges_dict = read_Gmsh_2D("/home/daniel/Desktop/mesh.msh")
+#mesh = read_Gmsh_2D("/home/daniel/Desktop/mesh.msh")
+
+# Create MeshData
+rd = RefElemData(Tri(), N=3)
+md = MeshData((VX, VY), EToV, rd)
+
+# Get boundary faces and nodes directly from Gmsh
+boundary_faces = StartUpDG.tag_boundary_faces_from_edges_dict(md, edges_dict)
+
+# Print summaries
+print_boundary_tags(boundary_faces)
+print_boundary_nodes_tags(boundary_nodes)
+
+# Access specific boundaries
+inlet_faces = boundary_faces[:inlet]
+wall_nodes = boundary_nodes[:wall]

--- a/src/boundary_utils.jl
+++ b/src/boundary_utils.jl
@@ -87,3 +87,101 @@ function tag_boundary_nodes(rd, md, boundary_list::Dict)
     node_tags = (mapM[:, boundary_faces[tag]] for tag in keys(boundary_faces))
     return Dict(Pair.(keys(boundary_list), node_tags))
 end
+
+
+# TODO: Implement tagging of boundary nodes & faces based on physical names
+# IDEA: Maybe compute the face cnetroid for the labeled faces and then use these to identify the boundary indices?
+"""
+    tag_boundary_faces_from_edges_dict(md, edges_dict, boundary_names = :all; atol = 1e-13)
+ 
+Map edges from Gmsh `edges_dict` to boundary face indices in `MeshData` 
+by matching face centroids against edge midpoints.
+ 
+This is the most direct approach: compares the centroid of each DG boundary face
+to the precomputed midpoints of Gmsh edges with the same physical tag.
+ 
+# Arguments
+- `md`: MeshData object
+- `edges_dict`: Dictionary from `build_edges_dict()` with :midpoints field
+- `boundary_names`: Symbol(s) to extract (default `:all` for all boundaries)
+- `atol`: Absolute tolerance for coordinate matching (default 1e-13)
+ 
+# Returns
+`Dict{Symbol, Vector{Int}}` mapping boundary names to face indices in `md`
+ 
+# Example
+```julia
+coords, EToV, edges_dict, elem_type = read_Gmsh_2D_v2("mesh.msh")
+md = MeshData(coords, EToV, rd)
+boundary_faces = tag_boundary_faces_from_edges_dict(md, edges_dict)
+# boundary_faces[:bottom] => [1, 2, 5, 6, ...] (face indices)
+```
+"""
+function tag_boundary_faces_from_edges_dict(md, edges_dict, 
+                                            boundary_names::Union{Symbol, Vector{Symbol}} = :all;
+                                            atol = 1e-13)
+    
+    # Compute boundary face centroids (using existing StartUpDG function)
+    xyzb, boundary_face_ids = boundary_face_centroids(md)
+    xb, yb = xyzb[1], xyzb[2]  # Face centroids
+    
+    # Build a list of all Gmsh edge midpoints with their tags and names
+    gmsh_edge_midpoints = []  # Vector of (x, y, tag, name)
+    
+    for (name, info) in edges_dict
+        tag = info[:tag]
+        midpoints = get(info, :midpoints, [])
+        for (mx, my) in midpoints
+            push!(gmsh_edge_midpoints, (mx, my, tag, name))
+        end
+    end
+    
+    # Determine which boundaries to include
+    if boundary_names isa Symbol && boundary_names == :all
+        names_to_use = keys(edges_dict)
+    else
+        names_to_use = boundary_names isa Symbol ? [boundary_names] : boundary_names
+    end
+    
+    # Match face centroids to edge midpoints
+    result = Dict{Symbol, Vector{Int}}()
+    
+    for name in names_to_use
+        if !haskey(edges_dict, name)
+            @warn "Boundary '$name' not found in edges_dict. Skipping."
+            continue
+        end
+        
+        matched_faces = Int[]
+        target_tag = edges_dict[name][:tag]
+        
+        # For each boundary face
+        for (face_idx, face_id) in enumerate(boundary_face_ids)
+            face_x = xb[face_idx]
+            face_y = yb[face_idx]
+            
+            # Find nearest Gmsh edge midpoint with matching tag
+            best_dist = Inf
+            best_gmsh_edge = nothing
+            
+            for (mx, my, tag, gmsh_name) in gmsh_edge_midpoints
+                if tag == target_tag
+                    dist = sqrt((face_x - mx)^2 + (face_y - my)^2)
+                    if dist < best_dist
+                        best_dist = dist
+                        best_gmsh_edge = (mx, my, tag, gmsh_name)
+                    end
+                end
+            end
+            
+            # Match if within tolerance
+            if best_dist < atol
+                push!(matched_faces, face_id)
+            end
+        end
+        
+        result[name] = sort!(unique!(matched_faces))
+    end
+    
+    return result
+end

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -71,6 +71,75 @@ function remap_element_grouping(eg::Vector{Int})
 end
 
 """
+    parse_physical_names(lines::Vector{String})
+ 
+Extract physical name -> tag mapping from MSH 2.2 file.
+Returns: Dict{String, Int} mapping names to physical tags
+"""
+function parse_physical_names(lines::Vector{String})
+    physical_names = Dict{String, Int}()
+    
+    idx = findline("\$PhysicalNames", lines)
+    if idx == 0
+        return physical_names # No physical names defined
+    end
+    
+    n_physical = parse(Int64, lines[idx + 1])
+    for i in 1:n_physical
+        parts = split(lines[idx + 1 + i])
+        dim = parse(Int64, parts[1])
+        tag = parse(Int64, parts[2])
+        name = strip(parts[3], ['"'])
+        physical_names[name] = tag
+    end
+    
+    return physical_names
+end
+
+"""
+    build_edges_dict(edge_list::Vector, physical_names::Dict)
+ 
+Build a dictionary mapping physical tag names to edge information.
+ 
+Returns: Dict{Symbol, Dict} with structure:
+  :boundary_name => Dict(:tag => Int, :edges => Vector{Tuple}, :nodes => Vector{Int})
+"""
+function build_edges_dict(edge_list::Vector, physical_names::Dict)
+    edges_dict = Dict{Symbol, Dict}()
+    
+    # Invert physical_names to get tag -> name mapping
+    tag_to_name = Dict(v => k for (k, v) in physical_names)
+    
+    # Group edges by physical tag
+    edges_by_tag = Dict{Int64, Vector{Tuple{Int64, Int64}}}()
+    for (n1, n2, tag) in edge_list
+        if !haskey(edges_by_tag, tag)
+            edges_by_tag[tag] = Tuple{Int64, Int64}[]
+        end
+        push!(edges_by_tag[tag], (n1, n2))
+    end
+    
+    # Build result dictionary
+    for (tag, edges) in edges_by_tag
+        name = get(tag_to_name, tag, "boundary_$tag")
+        name_sym = Symbol(name)
+        
+        # Collect all unique nodes on this boundary
+        nodes = unique(vcat(first.(edges), last.(edges)))
+        sort!(nodes)
+        
+        edges_dict[name_sym] = Dict(
+            :tag => tag,
+            :edges => edges,
+            :nodes => nodes
+        )
+    end
+    
+    return edges_dict
+end
+
+
+"""
     function read_Gmsh_2D_v4(filename, options)
 
 reads triangular GMSH 2D .msh files.
@@ -273,9 +342,12 @@ function read_Gmsh_2D_v4(filename::String, groupOpt::Bool = false,
 end
 
 """
-    read_Gmsh_2D_v2(filename)
+    read_Gmsh_2D_v2(filename::String)
 
-Reads triangular GMSH 2D file format 2.2 0 8. Returns (VX, VY), EToV.
+Reads triangular GMSH 2D file format 2.2 0 8.
+Returns: (VX, VY), EToV, edges_dict
+where edges_dict maps physical_tag_names to edge connectivity and node lists.
+
 # Examples
 ```julia
 VXY, EToV = read_Gmsh_2D_v2("eulerSquareCylinder2D.msh")
@@ -286,43 +358,73 @@ https://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format-version-2-_0028Legacy_00
 function read_Gmsh_2D_v2(filename::String)
     f = open(filename)
     lines = readlines(f)
-
+    close(f)
+ 
+    # Parse format
     format_line = findline("\$MeshFormat", lines) + 1
     version, _, dataSize = split(lines[format_line])
     gmsh_version = parse(Float64, version)
     @assert gmsh_version == 2.2
-
+ 
+    # Parse physical names (to get name -> tag mapping)
+    physical_names = parse_physical_names(lines)
+ 
+    # Parse nodes
     node_start = findline("\$Nodes", lines) + 1
     Nv = parse(Int64, lines[node_start])
     VX, VY, VZ = ntuple(x -> zeros(Float64, Nv), 3)
     for i in 1:Nv
         vals = [parse(Float64, c) for c in split(lines[i + node_start])]
-        # first entry =
         VX[i] = vals[2]
         VY[i] = vals[3]
     end
-
+ 
+    # Parse elements and edges
     elem_start = findline("\$Elements", lines) + 1
     K_all = parse(Int64, lines[elem_start])
+    
+    # First pass: count triangular elements
     K = 0
     for e in 1:K_all
         if length(split(lines[e + elem_start])) == 8
             K = K + 1
         end
     end
+    K > 0 || error("No triangular elements found in mesh")
+ 
+    # Allocate arrays
     EToV = zeros(Int64, K, 3)
+    edge_list = Vector{Tuple{Int64, Int64, Int64}}() # (node1, node2, physical_tag)
+    
     sk = 1
     for e in 1:K_all
-        if length(split(lines[e + elem_start])) == 8
-            vals = [parse(Int64, c) for c in split(lines[e + elem_start])]
-            EToV[sk, :] .= vals[6:8]
+        # Gmsh 2.2 format: [elem_id, type, n_tags, tag1, tag2, ..., node1, node2]
+        fields = split(lines[e + elem_start])
+        el_type = parse(Int64, fields[2])
+        n_tags = parse(Int64, fields[3])
+
+        if el_type == 2 # Triangle
+            vals = [parse(Int64, c) for c in fields]
+            # offset of 3 due to elem_id, type, n_tags
+            node_indices = vals[3 + n_tags .+ (1:3)]
+            EToV[sk, :] .= node_indices
             sk = sk + 1
+        elseif el_type == 1 # Outer edge => boundary
+            vals = [parse(Int64, c) for c in fields]
+            physical_tag = vals[4] # `tag1` is physical tag (`tag2` is (geometric) entity tag)
+            node1 = vals[3 + n_tags + 1]
+            node2 = vals[3 + n_tags + 2]
+            push!(edge_list, (node1, node2, physical_tag))
         end
     end
-
+ 
+    # Correct negative Jacobians (for triangles)
     EToV = correct_negative_Jacobians!((VX, VY), EToV)
-
-    return (VX, VY), EToV
+ 
+    # Build edges dictionary indexed by physical tag name
+    edges_dict = build_edges_dict(edge_list, physical_names)
+ 
+    return (VX, VY), EToV, edges_dict
 end
 
 """

--- a/src/mesh/gmsh_utilities.jl
+++ b/src/mesh/gmsh_utilities.jl
@@ -102,10 +102,19 @@ end
 Build a dictionary mapping physical tag names to edge information.
  
 Returns: Dict{Symbol, Dict} with structure:
-  :boundary_name => Dict(:tag => Int, :edges => Vector{Tuple}, :nodes => Vector{Int})
+  :boundary_name => Dict(
+      :tag => Int,
+      :edges => Vector{Tuple},
+      :nodes => Vector{Int},
+      :midpoints => Vector{Tuple{Float64, Float64}},  # Edge midpoints
+      :n_edges => Int,
+      :n_nodes => Int
+  )
 """
-function build_edges_dict(edge_list::Vector, physical_names::Dict)
+function build_edges_dict(edge_list::Vector, physical_names::Dict, coords::Tuple)
     edges_dict = Dict{Symbol, Dict}()
+    
+    VX, VY = coords
     
     # Invert physical_names to get tag -> name mapping
     tag_to_name = Dict(v => k for (k, v) in physical_names)
@@ -128,15 +137,22 @@ function build_edges_dict(edge_list::Vector, physical_names::Dict)
         nodes = unique(vcat(first.(edges), last.(edges)))
         sort!(nodes)
         
+        # Compute edge midpoints
+        midpoints = [((VX[n1] + VX[n2])/2, (VY[n1] + VY[n2])/2) for (n1, n2) in edges]
+        
         edges_dict[name_sym] = Dict(
             :tag => tag,
             :edges => edges,
-            :nodes => nodes
+            :nodes => nodes,
+            :midpoints => midpoints,
+            :n_edges => length(edges),
+            :n_nodes => length(nodes)
         )
     end
     
     return edges_dict
 end
+
 
 
 """
@@ -422,7 +438,7 @@ function read_Gmsh_2D_v2(filename::String)
     EToV = correct_negative_Jacobians!((VX, VY), EToV)
  
     # Build edges dictionary indexed by physical tag name
-    edges_dict = build_edges_dict(edge_list, physical_names)
+    edges_dict = build_edges_dict(edge_list, physical_names, (VX, VY))
  
     return (VX, VY), EToV, edges_dict
 end


### PR DESCRIPTION
This is a first step to enable boundary assignment based on physical/geometric tags. This is required for more complicated geometries such as the flow around an airfoil (I am of course thinking about using this from Trixi.jl).

@macmccallum Could you take a look ?

I used AI for an initial version of this, but found myself eventually writing nearly all functions myself.